### PR TITLE
Change `Wichita, KA` to `Wichita, KS`

### DIFF
--- a/inst/extdata/city_to_intake_mapping.csv
+++ b/inst/extdata/city_to_intake_mapping.csv
@@ -685,8 +685,8 @@ Waterbury,CT,318,Shepaug Reservoir,3787,Waterbury | CT,TRUE
 Waterbury,CT,318,Wigwam Reservoir,3874,Waterbury | CT,TRUE
 Waterloo,IA,341,Cedar River Alluvial Aquifer - Waterloo,4035,Waterloo | IA,TRUE
 Waterloo,IA,341,Cedar Valley Aquifer,3275,Waterloo | IA,FALSE
-Wichita,KA,355,Cheney Reservoir,3281,Wichita | KA,TRUE
-Wichita,KA,355,Equus Beds- High Plains Aquifer,3345,Wichita | KA,FALSE
+Wichita,KS,355,Cheney Reservoir,3281,Wichita | KS,TRUE
+Wichita,KS,355,Equus Beds- High Plains Aquifer,3345,Wichita | KS,FALSE
 Wilmington,NC,392,Cape Fear River - Wilmington,4034,Wilmington | NC,TRUE
 Wilmington,NC,392,Castle Hayne Aquifer,3269,Wilmington | NC,FALSE
 Winston-Salem,NC,393,Salem Lake,3750,Winston-Salem | NC,TRUE


### PR DESCRIPTION
The correct abbreviation of Kansas is KS. This change will allow the counts to line up since all of the other datasets we have use KS. 