### PR TITLE
Fix missing watersheds.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,8 @@ Imports:
     car,
     stringr,
     units,
-    tidyr
+    tidyr,
+    methods
 Suggests: 
     testthat (>= 2.1.0),
     knitr,

--- a/R/count_teleconnections.R
+++ b/R/count_teleconnections.R
@@ -6,6 +6,7 @@
 #' @param crop_file_path path of crop cover raster
 #' @param dams_file_path path of National Inventory of Dams "NID" point file
 #' @param irrigation_file_path path of edited demeter irrigation file.
+#' @param nuld_file_path path of land use raster file.
 #' @param cities a vector of cities to be included in the count. If omitted, all cities will be included.
 #' @param poly_slices integer for how may parts to split the watersheds polygons into to enable faster zonal stats
 #' @param n_cores integer for the number of machine cores used to run the polygon slicing function. 2 is default for users with 16GB of RAM.

--- a/R/io.R
+++ b/R/io.R
@@ -96,6 +96,7 @@ get_cities <- function(){
                          city_uid = col_integer(),
                          intake = col_character(),
                          DVSN_ID = col_integer(),
+                         DVTR_ID = col_integer(),
                          city_state = col_character())
   )
 }

--- a/inst/extdata/city_to_intake_mapping.csv
+++ b/inst/extdata/city_to_intake_mapping.csv
@@ -1,712 +1,889 @@
-city,state,city_uid,intake,DVSN_ID,city_state,key_watershed
-Abilene,TX,441,Clear Fork Brazo River,3289,Abilene | TX,TRUE
-Abilene,TX,441,Ft. Phantom Hill Reservoir,3364,Abilene | TX,FALSE
-Abilene,TX,441,Hubbard Creek Reservoir,3407,Abilene | TX,TRUE
-Abilene,TX,441,Lake Abilene,3445,Abilene | TX,TRUE
-Abilene,TX,441,Lake Kirby,3491,Abilene | TX,TRUE
-Akron,OH,410,East Branch Reservoir-OH,3329,Akron | OH,FALSE
-Akron,OH,410,Lake Rockwell,3526,Akron | OH,TRUE
-Akron,OH,410,Wendell R LaDue Reservoir,3862,Akron | OH,FALSE
-Albany,NY,404,Alcove Reservoir,3176,Albany | NY,TRUE
-Albany,NY,404,Basic Creek Reservoir,3210,Albany | NY,TRUE
-Albuquerque,NM,401,Rio Grande - Albuquerque,4045,Albuquerque | NM,TRUE
-Albuquerque,NM,401,Santa Fe Group Aquifer,3771,Albuquerque | NM,FALSE
-Amarillo,TX,442,Ogallala Aquifer,3666,Amarillo | TX,TRUE
-Ann Arbor,MI,371,Ann Arbor GW,3187,Ann Arbor | MI,FALSE
-Ann Arbor,MI,371,Barton Pond,3209,Ann Arbor | MI,TRUE
-Antioch,CA,289,Contra Loma Reservoir,3301,Antioch | CA,FALSE
-Antioch,CA,289,Los Vaqueros Reservoir,3571,Antioch | CA,FALSE
-Antioch,CA,289,Mallard Reservoir,3581,Antioch | CA,TRUE
-Antioch,CA,289,Martinez Reservoir,3589,Antioch | CA,TRUE
-Antioch,CA,289,San Joaquin River,3760,Antioch | CA,TRUE
-Appleton,WI,465,Lake Winnebago,3547,Appleton | WI,TRUE
-Asheville,NC,383,Bee Tree Reservoir,3216,Asheville | NC,TRUE
-Asheville,NC,383,Mills River,3616,Asheville | NC,TRUE
-Asheville,NC,383,North Fork Reservoir,3656,Asheville | NC,TRUE
-Athens,GA,334,Bear Creek Reservoir- GA,3214,Athens | GA,TRUE
-Athens,GA,334,Middle Oconee River,3610,Athens | GA,TRUE
-Athens,GA,334,North Oconee River,3657,Athens | GA,TRUE
-Atlanta,GA,181,Chattahoochee River,2331,Atlanta | GA,TRUE
-Atlantic City,NJ,399,Cohansey Aquifer,3295,Atlantic City | NJ,FALSE
-Atlantic City,NJ,399,Doughty Pond Dam,3325,Atlantic City | NJ,TRUE
-Atlantic City,NJ,399,Kirkwood Aquifer,3438,Atlantic City | NJ,FALSE
-Atlantic City,NJ,399,Kuehnle Pond Dam,3440,Atlantic City | NJ,FALSE
-Augusta-Richmond,GA,337,Cretaceous Aquifer,3304,Augusta-Richmond | GA,FALSE
-Augusta-Richmond,GA,337,Savannah River,3777,Augusta-Richmond | GA,TRUE
-Aurora,CO,187,Aurora Reservoir,2348,Aurora | CO,TRUE
-Aurora,CO,187,Homestake Reservoir,2358,Aurora | CO,TRUE
-Aurora,CO,187,Jefferson Reservoir,2351,Aurora | CO,TRUE
-Aurora,CO,187,Lake Henry,2356,Aurora | CO,FALSE
-Aurora,CO,187,Lake Meredith,2357,Aurora | CO,TRUE
-Aurora,CO,187,Pueblo Reservoir,2355,Aurora | CO,TRUE
-Aurora,CO,187,Quincy Reservoir,2349,Aurora | CO,TRUE
-Aurora,CO,187,Rampart Reservoir,2352,Aurora | CO,TRUE
-Aurora,CO,187,South Platte River Basin,2347,Aurora | CO,FALSE
-Aurora,CO,187,Spinney Mountain Reservoir,2350,Aurora | CO,TRUE
-Aurora,CO,187,Turquoise Lake,2353,Aurora | CO,FALSE
-Aurora,CO,187,Twin Lakes,2354,Aurora | CO,FALSE
-Austin,TX,167,Colorado River (TX) - Albert H. Ullrich WTP,2284,Austin | TX,TRUE
-Austin,TX,167,Colorado River (TX) - Albert R. Davis WTP,2283,Austin | TX,FALSE
-Bakersfield,CA,290,Bakersfield_GW,3203,Bakersfield | CA,FALSE
-Bakersfield,CA,290,Kern River,3432,Bakersfield | CA,TRUE
-Baltimore,MD,172,Conowingo Dam – Susquehanna River,2301,Baltimore | MD,TRUE
-Baltimore,MD,172,Liberty Reservoir,2299,Baltimore | MD,TRUE
-Baltimore,MD,172,Loch Raven Reservoir,2298,Baltimore | MD,TRUE
-Baltimore,MD,172,Prettyboy Reservoir,2300,Baltimore | MD,FALSE
-Barnstable,MA,365,Sagamore Lens,4072,Barnstable | MA,TRUE
-Baton Rouge,LA,358,Southern Hills Aquifer,3804,Baton Rouge | LA,TRUE
-Beaumont,TX,443,Neches River,3644,Beaumont | TX,TRUE
-Berkeley,CA,555,Briones Reservoir,2335,Berkeley | CA,TRUE
-Berkeley,CA,555,Camanche Reservoir,2340,Berkeley | CA,TRUE
-Billings,MT,382,Yellowstone River,3883,Billings | MT,TRUE
-Binghamton,NY,409,Susquehanna River - Binghampton,4036,Binghamton | NY,TRUE
-Birmingham,AL,281,Cahaba River,3253,Birmingham | AL,TRUE
-Birmingham,AL,281,Inland Lake,3415,Birmingham | AL,TRUE
-Birmingham,AL,281,Lake Purdy,3521,Birmingham | AL,TRUE
-Birmingham,AL,281,Mulberry Fork,3637,Birmingham | AL,FALSE
-Birmingham,AL,281,Sipsey Fork,3796,Birmingham | AL,TRUE
-Boise,ID,344,Boise GW,3234,Boise | ID,FALSE
-Boise,ID,344,Boise River,3235,Boise | ID,TRUE
-Boston,MA,173,Quabbin Reservoir,2302,Boston | MA,TRUE
-Boston,MA,173,Wachusett Reservoir,2303,Boston | MA,TRUE
-Boston,MA,173,Ware River,2304,Boston | MA,TRUE
-Boulder,CO,312,Barker Reservoir,3205,Boulder | CO,TRUE
-Boulder,CO,312,Boulder Reservoir,3238,Boulder | CO,TRUE
-Boulder,CO,312,Carter Lake,4033,Boulder | CO,TRUE
-Boulder,CO,312,Lakewood Reservoir,4030,Boulder | CO,TRUE
-Boulder,CO,312,Silver Lake,3790,Boulder | CO,FALSE
-Bremerton,WA,461,Bremerton GW,3242,Bremerton | WA,FALSE
-Bremerton,WA,461,Union River Reservoir,3849,Bremerton | WA,TRUE
-Bridgeport,CT,512,Aspetuck Reservoir,4082,Bridgeport | CT,FALSE
-Bridgeport,CT,512,Easton Reservoir,4079,Bridgeport | CT,TRUE
-Bridgeport,CT,512,Far Mill Reservoir,4083,Bridgeport | CT,FALSE
-Bridgeport,CT,512,Hemlocks Reservoir,4080,Bridgeport | CT,TRUE
-Bridgeport,CT,512,Means Brook Reservoir,4085,Bridgeport | CT,TRUE
-Bridgeport,CT,512,Saugatuck Reservoir,4078,Bridgeport | CT,TRUE
-Bridgeport,CT,512,Trap Fall Reservoir,4081,Bridgeport | CT,TRUE
-Bridgeport,CT,512,West Pequonnock Reservoir,4084,Bridgeport | CT,TRUE
-Brooksville,FL,320,Floridan Aquifer,4071,Brooksville | FL,TRUE
-Brownsville,TX,444,Amistad Dam,3185,Brownsville | TX,FALSE
-Brownsville,TX,444,Falcon Dam,3348,Brownsville | TX,TRUE
-Buffalo,NY,405,Lake Erie,3469,Buffalo | NY,TRUE
-Burlington,VT,460,Lake Champlain,3459,Burlington | VT,TRUE
-Canton,OH,411,Canton Sand and Gravel Aquifer,3262,Canton | OH,TRUE
-Cape Coral,FL,321,Lower Hawthorne Aquifer,3575,Cape Coral | FL,TRUE
-Cedar Rapids,IA,339,Cedar River Alluvial Aquifer - Cedar Rapids,3273,Cedar Rapids | IA,TRUE
-Champaign,IL,345,Glasford Aquifer,3370,Champaign | IL,TRUE
-Champaign,IL,345,Mahomet Sands Aquifer,3580,Champaign | IL,TRUE
-Charleston,WV,471,Elk River,3342,Charleston | WV,TRUE
-Charlotte,NC,170,Lake Norman,2296,Charlotte | NC,FALSE
-Charlotte,NC,170,Mountain Island Lake,2295,Charlotte | NC,TRUE
-Chattanooga,TN,438,Tennessee River - Chattanooga,4050,Chattanooga | TN,TRUE
-Chicago,IL,160,Lake Michigan,3506,Chicago | IL,TRUE
-Cincinnati,OH,413,Great Miami Aquifer,3377,Cincinnati | OH,FALSE
-Cincinnati,OH,413,Ohio River - Cincinnati,3668,Cincinnati | OH,TRUE
-Clarksville,TN,439,Cumberland River - Clarksville,4039,Clarksville | TN,TRUE
-Cleveland,OH,183,Lake Erie,3469,Cleveland | OH,TRUE
-Colorado Springs,CO,313,Big Horn Reservoir,3223,Colorado Springs | CO,TRUE
-Colorado Springs,CO,313,Big Tooth Reservoir,3226,Colorado Springs | CO,TRUE
-Colorado Springs,CO,313,Boehmer Reservoir,3231,Colorado Springs | CO,FALSE
-Colorado Springs,CO,313,Clear Creek Reservoir,3288,Colorado Springs | CO,TRUE
-Colorado Springs,CO,313,Crystal Creek Reservoir-CO,3308,Colorado Springs | CO,TRUE
-Colorado Springs,CO,313,Grizzly Reservoir,3383,Colorado Springs | CO,TRUE
-Colorado Springs,CO,313,Lake Moraine,3507,Colorado Springs | CO,FALSE
-Colorado Springs,CO,313,Mason Reservoir,3590,Colorado Springs | CO,FALSE
-Colorado Springs,CO,313,McReynolds Reservoir,3596,Colorado Springs | CO,TRUE
-Colorado Springs,CO,313,Montgomery Reservoir,3629,Colorado Springs | CO,TRUE
-Colorado Springs,CO,313,Nichols Reservoir,3651,Colorado Springs | CO,FALSE
-Colorado Springs,CO,313,North Catamount Reservoir,3654,Colorado Springs | CO,FALSE
-Colorado Springs,CO,313,Northfield Reservoir,3660,Colorado Springs | CO,FALSE
-Colorado Springs,CO,313,Pikeview Reservoir,3689,Colorado Springs | CO,TRUE
-Colorado Springs,CO,313,Rosemont Reservoir,3742,Colorado Springs | CO,TRUE
-Colorado Springs,CO,313,Ruedi Reservoir,3744,Colorado Springs | CO,TRUE
-Colorado Springs,CO,313,South Catamount Reservoir,3801,Colorado Springs | CO,FALSE
-Colorado Springs,CO,313,Upper Blue Reservoir,3850,Colorado Springs | CO,TRUE
-Colorado Springs,CO,313,Wilson Reservoir,3879,Colorado Springs | CO,TRUE
-Columbia,SC,429,Broad River Diversion Canal,3244,Columbia | SC,TRUE
-Columbia,SC,429,Lake Murray,3508,Columbia | SC,FALSE
-Columbus,OH,168,Griggs Reservoir - dammed Scioto R.,2285,Columbus | OH,TRUE
-Columbus,OH,168,Hoover Reservoir,2287,Columbus | OH,TRUE
-Columbus,OH,168,O'Shaughnessy Reservoir - dammed Scioto R.,2286,Columbus | OH,FALSE
-Columbus,OH,168,Scioto River Valley Aquifer,2288,Columbus | OH,FALSE
-Concord,CA,291,Clifton Forebay,2190,Concord | CA,FALSE
-Concord,CA,291,Contra Loma Reservoir,3301,Concord | CA,FALSE
-Concord,CA,291,Lewiston Lake,2189,Concord | CA,TRUE
-Concord,CA,291,Los Vaqueros Reservoir,3571,Concord | CA,FALSE
-Concord,CA,291,Mallard Reservoir,3581,Concord | CA,TRUE
-Concord,CA,291,Martinez Reservoir,3589,Concord | CA,TRUE
-Concord,CA,291,San Joaquin River,3760,Concord | CA,TRUE
-Concord,NC,384,Kannapolis Lake,3425,Concord | NC,TRUE
-Concord,NC,384,Lake Concord,3460,Concord | NC,TRUE
-Concord,NC,384,Lake Don T. Howell,3466,Concord | NC,TRUE
-Concord,NC,384,Lake Fisher,3472,Concord | NC,FALSE
-Concord,NC,384,Lake Norman,2296,Concord | NC,FALSE
-Concord,NC,384,Mountain Island Lake,2295,Concord | NC,TRUE
-Corpus Christi,TX,445,Choke Canyon Reservoir,3286,Corpus Christi | TX,FALSE
-Corpus Christi,TX,445,Lake Corpus Christi,3462,Corpus Christi | TX,TRUE
-Corpus Christi,TX,445,Lake Texana,3536,Corpus Christi | TX,TRUE
-Dallas,TX,159,Elm Fork of the Trinity River - Elm Fork WTP,2192,Dallas | TX,TRUE
-Dallas,TX,159,Fork Lake,2198,Dallas | TX,TRUE
-Dallas,TX,159,Grapevine Lake,2195,Dallas | TX,FALSE
-Dallas,TX,159,Lewisville Lake,2194,Dallas | TX,FALSE
-Dallas,TX,159,Ray Hubbard Lake,2196,Dallas | TX,TRUE
-Dallas,TX,159,Ray Roberts Lake,2193,Dallas | TX,FALSE
-Dallas,TX,159,Tawakoni Lake,2197,Dallas | TX,TRUE
-Danbury,CT,319,East Lake,3332,Danbury | CT,FALSE
-Danbury,CT,319,Kenosia Wells,3429,Danbury | CT,FALSE
-Danbury,CT,319,Lower Kohanza Reservoir,3576,Danbury | CT,TRUE
-Danbury,CT,319,Margerie Reservoir,3585,Danbury | CT,FALSE
-Danbury,CT,319,Osborne Wells,3672,Danbury | CT,FALSE
-Danbury,CT,319,Padanaram Reservoir,3678,Danbury | CT,TRUE
-Danbury,CT,319,Upper Kohanza Reservoir,3851,Danbury | CT,FALSE
-Danbury,CT,319,West Lake,3865,Danbury | CT,FALSE
-Davenport,IA,342,Mississippi River - Davenport,3621,Davenport | IA,TRUE
-Dayton,OH,412,Miami Valley Buried Aquifer,3607,Dayton | OH,TRUE
-Deltona,FL,322,Floridan Aquifer,3360,Deltona | FL,TRUE
-Denver,CO,176,Antero Reservoir,2313,Denver | CO,FALSE
-Denver,CO,176,Bear Creek (to canal),2318,Denver | CO,TRUE
-Denver,CO,176,Cheesman Reservoir,2315,Denver | CO,FALSE
-Denver,CO,176,Dillon Reservoir,2311,Denver | CO,TRUE
-Denver,CO,176,Eleven Mile Canyon Reservoir,2314,Denver | CO,FALSE
-Denver,CO,176,Gross Reservoir,2316,Denver | CO,TRUE
-Denver,CO,176,Ralston Reservoir,2319,Denver | CO,TRUE
-Denver,CO,176,Strontia Springs Reservoir,2317,Denver | CO,TRUE
-Denver,CO,176,Tributaries to Fraser River (Moffat Tunnel),2312,Denver | CO,TRUE
-Denver,CO,176,Williams Fork River intake,2320,Denver | CO,TRUE
-Des Moines,IA,340,Des Moines River,3318,Des Moines | IA,TRUE
-Des Moines,IA,340,Raccoon River,3721,Des Moines | IA,TRUE
-Des Moines,IA,340,Raccoon River Alluvial Aquifer,3722,Des Moines | IA,FALSE
-Detroit,MI,171,Lake Huron,3487,Detroit | MI,FALSE
-Detroit,MI,171,Lake St. Clair - 3 WTP intakes,2308,Detroit | MI,TRUE
-Duluth,MN,378,Lake Superior,3533,Duluth | MN,TRUE
-Durham,NC,385,Lake Jordan,3489,Durham | NC,TRUE
-Durham,NC,385,Lake Michie,3505,Durham | NC,TRUE
-Durham,NC,385,Little River Reservoir,3562,Durham | NC,TRUE
-El Paso,TX,455,Hueco Bolson Aquifer,3409,El Paso | TX,FALSE
-El Paso,TX,455,Mesilla Bolson Aquifer,3606,El Paso | TX,FALSE
-El Paso,TX,455,Rio Grande River - El Paso,3733,El Paso | TX,TRUE
-Elkhart,IN,352,Elkhart GW,3343,Elkhart | IN,TRUE
-Erie,PA,421,Lake Erie,3469,Erie | PA,TRUE
-Eugene,OR,418,McKenzie River,3595,Eugene | OR,TRUE
-Evansville,IN,351,Ohio River - Evansville,4042,Evansville | IN,TRUE
-Fairfield,CA,292,Lake Berryessa,3451,Fairfield | CA,TRUE
-Fargo,ND,394,Red River,3727,Fargo | ND,TRUE
-Fayetteville,NC,386,Bonnie Doone Lake,3237,Fayetteville | NC,FALSE
-Fayetteville,NC,386,Cape Fear River - Fayetteville,3264,Fayetteville | NC,TRUE
-Fayetteville,NC,386,Glenville Lake,3372,Fayetteville | NC,TRUE
-Fayetteville,NC,386,Jacobson Reservoir,3419,Fayetteville | NC,TRUE
-Fayetteville,NC,386,Kornbow Lake,3439,Fayetteville | NC,FALSE
-Fayetteville,NC,386,Mintz Pond,3617,Fayetteville | NC,FALSE
-Flint,MI,372,Detroit River,2307,Flint | MI,TRUE
-Fort Collins,CO,314,Cache La Poudre River,3252,Fort Collins | CO,TRUE
-Fort Collins,CO,314,Flat Iron Dam,3357,Fort Collins | CO,TRUE
-Fort Collins,CO,314,Green Mountain Dam,3380,Fort Collins | CO,TRUE
-Fort Collins,CO,314,Horsetooth Reservoir,3405,Fort Collins | CO,TRUE
-Fort Collins,CO,314,Joe Wright Reservoir,4032,Fort Collins | CO,FALSE
-Fort Collins,CO,314,Lake Granby,3375,Fort Collins | CO,FALSE
-Fort Collins,CO,314,Michigan River,4031,Fort Collins | CO,TRUE
-Fort Collins,CO,314,Olympus Dam,3670,Fort Collins | CO,TRUE
-Fort Collins,CO,314,Shadow Mountain Dam,3785,Fort Collins | CO,FALSE
-Fort Collins,CO,314,Willow Creek Dam,3878,Fort Collins | CO,FALSE
-Fort Collins,CO,314,Windy Gap Reservoir,3880,Fort Collins | CO,TRUE
-Fort Smith,AR,287,Lake Fort Smith,3473,Fort Smith | AR,TRUE
-Fort Smith,AR,287,Lee Creek Reservoir,3553,Fort Smith | AR,TRUE
-Fort Walton Beach,FL,323,Floridan Aquifer,3360,Fort Walton Beach | FL,TRUE
-Fort Wayne,IN,349,Cedarville Dam,3276,Fort Wayne | IN,FALSE
-Fort Wayne,IN,349,Hurshtown Reservoir,3411,Fort Wayne | IN,FALSE
-Fort Wayne,IN,349,St. Joseph River,3653,Fort Wayne | IN,TRUE
-Fort Worth,TX,169,Benbrook Lake,2292,Fort Worth | TX,TRUE
-Fort Worth,TX,169,Cedar Creek Reservoir,2293,Fort Worth | TX,TRUE
-Fort Worth,TX,169,Eagle Mountain Lake,2290,Fort Worth | TX,FALSE
-Fort Worth,TX,169,Lake Bridgeport,2289,Fort Worth | TX,FALSE
-Fort Worth,TX,169,Lake Worth,2291,Fort Worth | TX,TRUE
-Fort Worth,TX,169,Richland-Chambers Reservoir,2294,Fort Worth | TX,TRUE
-Frederick,MD,369,Fishing Creek Reservoir,3356,Frederick | MD,FALSE
-Frederick,MD,369,Linganore Creek Reservoir,3559,Frederick | MD,TRUE
-Frederick,MD,369,Monocacy River,3628,Frederick | MD,TRUE
-Frederick,MD,369,Potomac River - Fredrick,3703,Frederick | MD,TRUE
-Fresno,CA,293,Fresno Sole Source Aquifer,3363,Fresno | CA,FALSE
-Fresno,CA,293,Millerton Lake,3614,Fresno | CA,TRUE
-Fresno,CA,293,Pine Flat Lake,3691,Fresno | CA,TRUE
-Gainesville,FL,324,Floridan Aquifer,3360,Gainesville | FL,TRUE
-Gastonia,NC,387,Mountain Island Lake,4886,Gastonia | NC,TRUE
-Grand Rapids,MI,373,Lake Michigan,3506,Grand Rapids | MI,TRUE
-Green Bay,WI,466,Green Bay GW,3379,Green Bay | WI,TRUE
-Greensboro,NC,388,Lake Brandt,3455,Greensboro | NC,FALSE
-Greensboro,NC,388,Lake Higgins,3484,Greensboro | NC,FALSE
-Greensboro,NC,388,Lake Mackintosh,3496,Greensboro | NC,TRUE
-Greensboro,NC,388,Lake Reidsville,3524,Greensboro | NC,TRUE
-Greensboro,NC,388,Lake Townsend,3538,Greensboro | NC,TRUE
-Greensboro,NC,388,Stoney Creek Reservoir,3819,Greensboro | NC,TRUE
-Greensboro,NC,388,Yadkin River - Greensboro,3882,Greensboro | NC,TRUE
-Greenville,SC,430,Lake Keowee,3490,Greenville | SC,TRUE
-Greenville,SC,430,Poinsett Reservoir,3698,Greenville | SC,TRUE
-Greenville,SC,430,Table Rock Reservoir,3829,Greenville | SC,TRUE
-Hagerstown,MD,370,Edgemeont Reservoir,3336,Hagerstown | MD,TRUE
-Hagerstown,MD,370,Potomac River - Hagerstown,4054,Hagerstown | MD,TRUE
-Harlingen,TX,446,Rio Grande - Harlingen,4046,Harlingen | TX,TRUE
-Harrisburg,PA,422,Stony Creek,3821,Harrisburg | PA,FALSE
-Harrisburg,PA,422,Susquehanna River - Harrisburg,4037,Harrisburg | PA,TRUE
-Harrisburg,PA,422,Swatara Creek,3827,Harrisburg | PA,TRUE
-Hartford,CT,316,Barkhamsted Reservoir,3206,Hartford | CT,FALSE
-Hartford,CT,316,Nepaug Reservoir,3645,Hartford | CT,TRUE
-Hemet,CA,294,Hemet Groundwater Basin,3391,Hemet | CA,TRUE
-Hemet,CA,294,San Jacinto Groundwater Basin,3758,Hemet | CA,TRUE
-Hickory,NC,389,Lake Hickory,3483,Hickory | NC,TRUE
-Hickory,NC,389,Lake Rhodhiss,3525,Hickory | NC,FALSE
-High Point,NC,390,City Lake,3287,High Point | NC,TRUE
-High Point,NC,390,Oak Hollow,3663,High Point | NC,FALSE
-Houma,LA,359,Bayou Lafourche,3213,Houma | LA,TRUE
-Houma,LA,359,Gulf Intercoastal Waterway,3386,Houma | LA,TRUE
-Houston,TX,154,Chicot Aquifer,2140,Houston | TX,FALSE
-Houston,TX,154,Evangeline Aquifer,2139,Houston | TX,FALSE
-Houston,TX,154,Lake Conroe,2142,Houston | TX,FALSE
-Houston,TX,154,Lake Houston,2143,Houston | TX,TRUE
-Houston,TX,154,Lake Livingston,2141,Houston | TX,TRUE
-Huntington,WV,472,Ohio River - Huntington,4044,Huntington | WV,TRUE
-Huntsville,AL,282,Huntsville_GW,3410,Huntsville | AL,FALSE
-Huntsville,AL,282,Tennessee River - Huntsville,3834,Huntsville | AL,TRUE
-Indianapolis,IN,165,Eagle Creek Reservoir,2278,Indianapolis | IN,TRUE
-Indianapolis,IN,165,Fall Creek - Fall Creek Plant,2277,Indianapolis | IN,FALSE
-Indianapolis,IN,165,Geist Reservoir,2276,Indianapolis | IN,FALSE
-Indianapolis,IN,165,Morse Reservoir,2275,Indianapolis | IN,FALSE
-Indianapolis,IN,165,Unnamed Aquifer,2279,Indianapolis | IN,FALSE
-Indianapolis,IN,165,White River - White River Plant,2274,Indianapolis | IN,TRUE
-Jackson,MS,381,Pearl River,3683,Jackson | MS,TRUE
-Jackson,MS,381,Ross Barnett Reservoir,3743,Jackson | MS,FALSE
-Jacksonville,FL,164,Floridan Aquifer,2273,Jacksonville | FL,TRUE
-Johnson City,TN,434,Unicoi Springs,3848,Johnson City | TN,FALSE
-Johnson City,TN,434,Watauga River,3861,Johnson City | TN,TRUE
-Kalamazoo,MI,374,Kalamazoo Sand and Gravel Aquifer,3424,Kalamazoo | MI,TRUE
-Kansas City,MO,380,Kansas City GW,3426,Kansas City | MO,FALSE
-Kansas City,MO,380,Missouri River,3622,Kansas City | MO,TRUE
-Kenosha,WI,467,Lake Michigan,3506,Kenosha | WI,TRUE
-Killeen,TX,447,Lake Belton,3449,Killeen | TX,TRUE
-Kissimmee,FL,325,Floridan Aquifer,3360,Kissimmee | FL,TRUE
-Knoxville,TN,435,Tennessee River - Knoxville,4049,Knoxville | TN,TRUE
-Lafayette,IN,350,Teays Aquifer,3832,Lafayette | IN,TRUE
-Lafayette,LA,360,NA,NA,Lafayette | LA,TRUE
-Lake Charles,LA,361,NA,NA,Lake Charles | LA,TRUE
-Lakeland,FL,326,Floridan Aquifer,3360,Lakeland | FL,TRUE
-Lancaster,PA,423,Conestoga River,3300,Lancaster | PA,TRUE
-Lancaster,PA,423,Susquehanna River - Lancaster,3825,Lancaster | PA,TRUE
-Lansing,MI,375,Saginaw Formation,3748,Lansing | MI,TRUE
-Laredo,TX,448,Rio Grande - Laredo,4047,Laredo | TX,TRUE
-Las Cruces,NM,402,NA,NA,Las Cruces | NM,TRUE
-Las Vegas,NV,178,Lake Mead,2327,Las Vegas | NV,TRUE
-Las Vegas,NV,178,Las Vegas Valley Aquifer,2328,Las Vegas | NV,FALSE
-Lexington,KY,356,Kentucky River,3431,Lexington | KY,TRUE
-Lexington,KY,356,Lake Ellerslie,3468,Lexington | KY,FALSE
-Lincoln,NE,395,Lincoln Gravel Esker Aquifer,3558,Lincoln | NE,TRUE
-Little Rock,AR,286,Lake Maumelle,3500,Little Rock | AR,TRUE
-Little Rock,AR,286,Lake Winona,3548,Little Rock | AR,TRUE
-Long Beach,CA,179,San Gabriel Valley Basin,2329,Long Beach | CA,TRUE
-Los Angeles,CA,161,Baker Creek,2221,Los Angeles | CA,FALSE
-Los Angeles,CA,161,Big Pine Creek,2222,Los Angeles | CA,FALSE
-Los Angeles,CA,161,Bishop Creek,2220,Los Angeles | CA,FALSE
-Los Angeles,CA,161,Bouquet Reservoir,2201,Los Angeles | CA,TRUE
-Los Angeles,CA,161,Convict Creek,2217,Los Angeles | CA,FALSE
-Los Angeles,CA,161,Convict Lake,2202,Los Angeles | CA,FALSE
-Los Angeles,CA,161,Cottonwood Creek,2227,Los Angeles | CA,TRUE
-Los Angeles,CA,161,Drinkwater Reservoir,2203,Los Angeles | CA,TRUE
-Los Angeles,CA,161,Fairmont Reservoir,2204,Los Angeles | CA,TRUE
-Los Angeles,CA,161,Grant Lake,2205,Los Angeles | CA,FALSE
-Los Angeles,CA,161,Hot Creek,2216,Los Angeles | CA,FALSE
-Los Angeles,CA,161,Independence Creek,2225,Los Angeles | CA,TRUE
-Los Angeles,CA,161,Lake Crowley,2206,Los Angeles | CA,FALSE
-Los Angeles,CA,161,Lee Vining Creek,2212,Los Angeles | CA,TRUE
-Los Angeles,CA,161,Lone Pine Creek,2226,Los Angeles | CA,TRUE
-Los Angeles,CA,161,Los Angeles Reservoir,2207,Los Angeles | CA,TRUE
-Los Angeles,CA,161,McGee Creek,2218,Los Angeles | CA,FALSE
-Los Angeles,CA,161,North Haiwee Reservoir,2208,Los Angeles | CA,FALSE
-Los Angeles,CA,161,Owens River Below East Portal,2215,Los Angeles | CA,FALSE
-Los Angeles,CA,161,Owens River below Pine Creek,2224,Los Angeles | CA,FALSE
-Los Angeles,CA,161,Parker Creek,2214,Los Angeles | CA,TRUE
-Los Angeles,CA,161,Pleasant Valley Reservoir,2210,Los Angeles | CA,FALSE
-Los Angeles,CA,161,Rock Creek,2219,Los Angeles | CA,FALSE
-Los Angeles,CA,161,South Haiwee Reservoir,2209,Los Angeles | CA,TRUE
-Los Angeles,CA,161,Tenehemah Creek,2223,Los Angeles | CA,FALSE
-Los Angeles,CA,161,Tinemaha Reservoir,2211,Los Angeles | CA,TRUE
-Los Angeles,CA,161,Walker Creek,2213,Los Angeles | CA,TRUE
-Louisville,KY,357,Ohio River - Louisville,4043,Louisville | KY,TRUE
-Louisville,KY,357,Ohio River Alluvial Aquifer,3669,Louisville | KY,FALSE
-Lubbock,TX,449,Bailey County GW,3202,Lubbock | TX,FALSE
-Lubbock,TX,449,Lake Meredith-TX,3504,Lubbock | TX,TRUE
-Lubbock,TX,449,Roberts County GW,3737,Lubbock | TX,FALSE
-Macon,GA,335,Javors J. Lucas Lake,3421,Macon | GA,FALSE
-Macon,GA,335,Ocmulgee River,3665,Macon | GA,TRUE
-Madison,WI,468,Madison sandstone aquifer,3579,Madison | WI,TRUE
-Manchester,NH,397,Lake Massabesic,3498,Manchester | NH,TRUE
-Marysville,WA,462,Edward Springs GW,3337,Marysville | WA,FALSE
-Marysville,WA,462,Lake Goodwin well,3479,Marysville | WA,FALSE
-Marysville,WA,462,Spada Lake Reservoir,3805,Marysville | WA,TRUE
-Marysville,WA,462,Stillaguamish GW,3816,Marysville | WA,FALSE
-McAllen,TX,450,Rio Grande - McAllen,4048,McAllen | TX,TRUE
-Medford,OR,419,Big Butte Springs GW,3222,Medford | OR,TRUE
-Memphis,TN,440,Memphis Aquifer,3601,Memphis | TN,TRUE
-Merced,CA,295,Merced GW Basin,3603,Merced | CA,TRUE
-Mesa,AZ,180,Mesa Groundwater,2330,Mesa | AZ,TRUE
-Miami,FL,182,Biscayne Aquifer,2332,Miami | FL,TRUE
-Milwaukee,WI,469,Lake Michigan,3506,Milwaukee | WI,TRUE
-Minneapolis,MN,185,Mississippi River - Columbia Heights Filtration Plant,2341,Minneapolis | MN,TRUE
-Mission Viejo,CA,296,Mission Viejo GW,3620,Mission Viejo | CA,TRUE
-Mobile,AL,283,J.B. Converse Reservoir,3418,Mobile | AL,TRUE
-Modesto,CA,297,Modesto Basin,3624,Modesto | CA,FALSE
-Modesto,CA,297,Modesto Reservoir,3625,Modesto | CA,TRUE
-Modesto,CA,297,Tuolumne River,4056,Modesto | CA,TRUE
-Monroe,LA,362,Bayou Bartholomew,3211,Monroe | LA,FALSE
-Monroe,LA,362,Bayou DeSiard,3212,Monroe | LA,FALSE
-Monroe,LA,362,Black Bayou,3229,Monroe | LA,FALSE
-Monroe,LA,362,Ouachita River,3674,Monroe | LA,TRUE
-Montgomery,AL,284,Montgomery_GW,3630,Montgomery | AL,FALSE
-Montgomery,AL,284,Tallapoosa River,3830,Montgomery | AL,TRUE
-Murfreesboro,TN,436,East Fork Stones River,3331,Murfreesboro | TN,FALSE
-Murfreesboro,TN,436,J. Percy Priest Reservoir,3417,Murfreesboro | TN,TRUE
-Muskegon,MI,376,Lake Michigan,3506,Muskegon | MI,TRUE
-Myrtle Beach,SC,431,Atlantic Intracoastal Waterway,3199,Myrtle Beach | SC,TRUE
-Myrtle Beach,SC,431,Pee Dee River,3684,Myrtle Beach | SC,TRUE
-Myrtle Beach,SC,431,Waccamaw River,3856,Myrtle Beach | SC,TRUE
-Nashua,NH,398,Bowers Pond,3239,Nashua | NH,FALSE
-Nashua,NH,398,Harris Pond,3388,Nashua | NH,FALSE
-Nashua,NH,398,Holts Pond,3401,Nashua | NH,FALSE
-Nashua,NH,398,Merrimack River,3604,Nashua | NH,TRUE
-Nashua,NH,398,Nashua GW,3643,Nashua | NH,FALSE
-Nashua,NH,398,Supply Pond,3824,Nashua | NH,FALSE
-Nashville,TN,437,Cumberland River - Nashville-Davidson,3312,Nashville | TN,TRUE
-New Bedford,MA,366,Assawompset Pond,3197,New Bedford | MA,TRUE
-New Bedford,MA,366,Great Quittacas Pond,3378,New Bedford | MA,FALSE
-New Bedford,MA,366,Little Quittacas Pond,3561,New Bedford | MA,TRUE
-New Bedford,MA,366,Long Pond,3570,New Bedford | MA,TRUE
-New Bedford,MA,366,Pocksha Pond,3697,New Bedford | MA,FALSE
-New Haven,CT,317,Bethany Lake,3220,New Haven | CT,FALSE
-New Haven,CT,317,Cheshire Reservoir,3283,New Haven | CT,TRUE
-New Haven,CT,317,Glen Lake Reservoir,3371,New Haven | CT,FALSE
-New Haven,CT,317,Housatonic River Aquifer,3406,New Haven | CT,FALSE
-New Haven,CT,317,Lake Chamberlain,3458,New Haven | CT,FALSE
-New Haven,CT,317,Lake Dawson,3464,New Haven | CT,TRUE
-New Haven,CT,317,Lake Gallard,3475,New Haven | CT,TRUE
-New Haven,CT,317,Lake Hammonasset,3480,New Haven | CT,TRUE
-New Haven,CT,317,Lake Watrous,3545,New Haven | CT,FALSE
-New Haven,CT,317,Maltby Lakes,3582,New Haven | CT,TRUE
-New Haven,CT,317,Menuckatuck Reservoir,3602,New Haven | CT,TRUE
-New Haven,CT,317,Mill River Aquifer,3613,New Haven | CT,FALSE
-New Haven,CT,317,Millford Reservoir,3615,New Haven | CT,TRUE
-New Haven,CT,317,Quinnipiac Aquifer,3720,New Haven | CT,FALSE
-New Haven,CT,317,Wepawaug Reservoir,3863,New Haven | CT,TRUE
-New Haven,CT,317,Whitney Lake,3872,New Haven | CT,TRUE
-New Orleans,LA,363,Mississippi River - New Orleans,4055,New Orleans | LA,TRUE
-New York,NY,162,Amawalk Reservoir,2240,New York | NY,FALSE
-New York,NY,162,Ashokan Reservoir,2231,New York | NY,TRUE
-New York,NY,162,Bog Brook Reservoir,2238,New York | NY,FALSE
-New York,NY,162,Boyds Corner Reservoir,2234,New York | NY,FALSE
-New York,NY,162,Cannonsville Reservoir,2229,New York | NY,TRUE
-New York,NY,162,Cross River Reservoir,2243,New York | NY,FALSE
-New York,NY,162,Croton Falls Reservoir,2239,New York | NY,FALSE
-New York,NY,162,Diverting Reservoir,2245,New York | NY,FALSE
-New York,NY,162,East Branch Reservoir,2237,New York | NY,FALSE
-New York,NY,162,Gilead Lake,2248,New York | NY,FALSE
-New York,NY,162,Glenelda Lake,2247,New York | NY,FALSE
-New York,NY,162,Kenisco Reservoir,2246,New York | NY,TRUE
-New York,NY,162,Kirk Lake,2249,New York | NY,FALSE
-New York,NY,162,Middle Branch Reservoir,2236,New York | NY,FALSE
-New York,NY,162,Muscoot Reservoir,2242,New York | NY,FALSE
-New York,NY,162,Neversink Reservoir,2232,New York | NY,TRUE
-New York,NY,162,New Croton Reservoir,2241,New York | NY,TRUE
-New York,NY,162,Pepacton Reservoir,2230,New York | NY,TRUE
-New York,NY,162,Rondout Reservoir,2233,New York | NY,TRUE
-New York,NY,162,Schoharie Reservoir,2228,New York | NY,TRUE
-New York,NY,162,Titicus Reservoir,2244,New York | NY,FALSE
-New York,NY,162,West Branch Reservoir,2235,New York | NY,FALSE
-Newark,NJ,191,Canistear Reservoir,2366,Newark | NJ,FALSE
-Newark,NJ,191,Charlottesburg Reservoir,2364,Newark | NJ,FALSE
-Newark,NJ,191,Clinton Reservoir,2367,Newark | NJ,FALSE
-Newark,NJ,191,Echo Lake,2365,Newark | NJ,FALSE
-Newark,NJ,191,Monksville Reservoir,2370,Newark | NJ,FALSE
-Newark,NJ,191,Oak Ridge Reservoir,2368,Newark | NJ,FALSE
-Newark,NJ,191,Pompton River,2371,Newark | NJ,TRUE
-Newark,NJ,191,Ramapo River,2372,Newark | NJ,FALSE
-Newark,NJ,191,Wanaque Reservoir,2369,Newark | NJ,FALSE
-Norfolk,VA,556,Lake Lawson,4226,Norfolk | VA,TRUE
-Norfolk,VA,556,Lake Smith,4227,Norfolk | VA,TRUE
-Norfolk,VA,556,Lake Wright,4228,Norfolk | VA,FALSE
-Norfolk,VA,556,Little Creek Reservoir,4225,Norfolk | VA,TRUE
-Norfolk,VA,556,Norfolk GW,4223,Norfolk | VA,FALSE
-Oakland,CA,184,Briones Reservoir,2335,Oakland | CA,FALSE
-Oakland,CA,184,Camanche Reservoir,2340,Oakland | CA,TRUE
-Oakland,CA,184,Lafayette Reservoir,2336,Oakland | CA,TRUE
-Oakland,CA,184,Lake Chabot,2338,Oakland | CA,TRUE
-Oakland,CA,184,Pardee Reservoir,2339,Oakland | CA,FALSE
-Oakland,CA,184,San Pablo Reservoir,2334,Oakland | CA,TRUE
-Oakland,CA,184,Upper San Leandro Reservoir,2337,Oakland | CA,FALSE
-Ocala,FL,327,Floridan Aquifer,3360,Ocala | FL,TRUE
-Odessa,TX,451,Lake Ivie,3488,Odessa | TX,TRUE
-Odessa,TX,451,Lake Spence,3531,Odessa | TX,FALSE
-Odessa,TX,451,Lake Thomas,3537,Odessa | TX,TRUE
-Oklahoma City,OK,416,Atoka Reservoir,3200,Oklahoma City | OK,FALSE
-Oklahoma City,OK,416,Canton Lake,3261,Oklahoma City | OK,FALSE
-Oklahoma City,OK,416,Hefner Reservoir,3390,Oklahoma City | OK,TRUE
-Oklahoma City,OK,416,McGee Creek Reservoir,3593,Oklahoma City | OK,TRUE
-Oklahoma City,OK,416,Overholser Reservoir,3675,Oklahoma City | OK,TRUE
-Oklahoma City,OK,416,Stanley Draper Reservoir,3814,Oklahoma City | OK,TRUE
-Omaha,NE,396,Dakota Sandstone Aquifer - Omaha,4040,Omaha | NE,FALSE
-Omaha,NE,396,Missouri River - Omaha,4051,Omaha | NE,TRUE
-Omaha,NE,396,Platte River,3696,Omaha | NE,TRUE
-Orlando,FL,328,Lower Floridan Aquifer,3574,Orlando | FL,TRUE
-Oxnard,CA,298,Lake Bard,3448,Oxnard | CA,TRUE
-Oxnard,CA,298,Oxnard Plain GW Basin,3677,Oxnard | CA,FALSE
-Panama (USA),FL,329,Floridan Aquifer,3360,Panama (USA) | FL,TRUE
-Pensacola,FL,333,Florida Sand and Gravel Aquifer,3358,Pensacola | FL,TRUE
-Peoria,IL,346,Illinois River,3412,Peoria | IL,TRUE
-Peoria,IL,346,San Koty Aquifer,3762,Peoria | IL,FALSE
-Philadelphia,PA,155,Delaware River - Baxter Plant,2146,Philadelphia | PA,TRUE
-Philadelphia,PA,155,Schuylkill River - Belmont Plant,2145,Philadelphia | PA,TRUE
-Philadelphia,PA,155,Schuylkill River - Queen Lane Plant,2144,Philadelphia | PA,FALSE
-Phoenix,AZ,156,Apache Lake,2150,Phoenix | AZ,FALSE
-Phoenix,AZ,156,Bartlett Reservoir,2154,Phoenix | AZ,TRUE
-Phoenix,AZ,156,C. C. Cragin Reservoir,2155,Phoenix | AZ,TRUE
-Phoenix,AZ,156,Canyon Lake,2151,Phoenix | AZ,FALSE
-Phoenix,AZ,156,Horseshoe Reservoir,2153,Phoenix | AZ,FALSE
-Phoenix,AZ,156,Lake Pleasant,2148,Phoenix | AZ,TRUE
-Phoenix,AZ,156,Saguaro Lake,2152,Phoenix | AZ,TRUE
-Phoenix,AZ,156,Theodore Roosevelt Lake,2149,Phoenix | AZ,FALSE
-Pittsburgh,PA,424,Allegheny river,3177,Pittsburgh | PA,TRUE
-Port Arthur,TX,452,LNVA Canal,3565,Port Arthur | TX,TRUE
-Port Arthur,TX,452,Port Arthur Reservoir,3701,Port Arthur | TX,FALSE
-Port Arthur,TX,452,Terminal Reservoir-TX,3835,Port Arthur | TX,TRUE
-Port Saint Lucie,FL,330,Floridan Aquifer,3360,Port Saint Lucie | FL,TRUE
-Portland,ME,513,Sebago Lake,4086,Portland | ME,TRUE
-Portland,OR,177,Blue Lake Aquifer,2324,Portland | OR,FALSE
-Portland,OR,177,Bull Run Lake,2321,Portland | OR,FALSE
-Portland,OR,177,Bull Run Reservoir No. 1,2322,Portland | OR,FALSE
-Portland,OR,177,Bull Run Reservoir No. 2,2323,Portland | OR,TRUE
-Portland,OR,177,Portland Sand and Gravel Aquifer,2325,Portland | OR,FALSE
-Portland,OR,177,Troutdale Sandstone Aquifer,2326,Portland | OR,FALSE
-Providence,RI,428,Barden Reservoir,3204,Providence | RI,FALSE
-Providence,RI,428,Moswansicut Reservoir,3635,Providence | RI,FALSE
-Providence,RI,428,Ponneganset Reservoir,3700,Providence | RI,FALSE
-Providence,RI,428,Regulating Reservoir-RI,3729,Providence | RI,TRUE
-Providence,RI,428,Scituate Reservoir,3782,Providence | RI,FALSE
-Providence,RI,428,Westconnaug Reservoir,3867,Providence | RI,FALSE
-Pueblo,CO,315,Pueblo Reservoir,2355,Pueblo | CO,TRUE
-Pueblo,CO,315,Ruedi Reservoir,3744,Pueblo | CO,TRUE
-Pueblo,CO,315,Turquoise Lake,2353,Pueblo | CO,FALSE
-Pueblo,CO,315,Twin Lakes,2354,Pueblo | CO,FALSE
-Racine,WI,470,Lake Michigan,3506,Racine | WI,TRUE
-Raleigh,NC,391,Falls Lake,3352,Raleigh | NC,TRUE
-Reading,PA,425,Lake Ontelaunee,3513,Reading | PA,TRUE
-Redding,CA,299,Redding GW,3728,Redding | CA,FALSE
-Redding,CA,299,Sacramento River - Redding,4041,Redding | CA,TRUE
-Reno,NV,403,Boca Reservoir,3230,Reno | NV,TRUE
-Reno,NV,403,Donner Lake,3324,Reno | NV,FALSE
-Reno,NV,403,Independence Lake,3413,Reno | NV,FALSE
-Reno,NV,403,Lake Tahoe,3534,Reno | NV,FALSE
-Reno,NV,403,Reno GW,3730,Reno | NV,FALSE
-Richmond,VA,457,"James River, VA",4091,Richmond | VA,TRUE
-Roanoke,VA,458,Carvin Cove Reservoir,3267,Roanoke | VA,TRUE
-Roanoke,VA,458,Crystal Spring - VA,3310,Roanoke | VA,FALSE
-Roanoke,VA,458,Falling Creek Reservoir,3350,Roanoke | VA,TRUE
-Roanoke,VA,458,Roanoke GW,3735,Roanoke | VA,FALSE
-Roanoke,VA,458,Roanoke River,3736,Roanoke | VA,TRUE
-Roanoke,VA,458,Spring Hollow Reservoir,3809,Roanoke | VA,FALSE
-Rochester,NY,406,Canadice Lake,3257,Rochester | NY,FALSE
-Rochester,NY,406,Hemlock Lake,3392,Rochester | NY,TRUE
-Rockford,IL,347,Rockford GW,3738,Rockford | IL,FALSE
-Rockford,IL,347,Rogue River,3740,Rockford | IL,TRUE
-Sacramento,CA,300,American River - Sacramento,4069,Sacramento | CA,TRUE
-Sacramento,CA,300,Sacramento GW,4070,Sacramento | CA,FALSE
-Sacramento,CA,300,Sacramento River - Sacramento,4068,Sacramento | CA,FALSE
-Saginaw,MI,377,Lake Huron,3487,Saginaw | MI,TRUE
-Saint Louis,MO,189,Mississippi River - Chain of Rocks Plant,2361,Saint Louis | MO,TRUE
-Saint Louis,MO,189,Missouri River - Howard Bend Plant,2360,Saint Louis | MO,FALSE
-Saint Paul,MN,190,Mississippi River - Coon Rapids,2362,Saint Paul | MN,TRUE
-Saint Paul,MN,190,Prairie du Chien-Jordan Aquifer,2363,Saint Paul | MN,FALSE
-Saint Petersburg,FL,192,Floridan Aquifer,2560,Saint Petersburg | FL,TRUE
-Salem,OR,420,North Santiam River,3658,Salem | OR,TRUE
-Salinas,CA,301,Salinas GW,3751,Salinas | CA,TRUE
-Salt Lake City,UT,456,Jordan River,4073,Salt Lake City | UT,TRUE
-Salt Lake City,UT,456,Salt Lake City GW,4074,Salt Lake City | UT,FALSE
-San Antonio,TX,157,Canyon Lake,2159,San Antonio | TX,FALSE
-San Antonio,TX,157,Carrizo Aquifer,2157,San Antonio | TX,FALSE
-San Antonio,TX,157,Edwards Aquifer,2156,San Antonio | TX,FALSE
-San Antonio,TX,157,Lake Dunlap,4028,San Antonio | TX,TRUE
-San Antonio,TX,157,Medina Lake,4029,San Antonio | TX,TRUE
-San Antonio,TX,157,Trinity Aquifer,2158,San Antonio | TX,FALSE
-San Diego,CA,158,Barrett Reservoir,2170,San Diego | CA,TRUE
-San Diego,CA,158,Castaic Lake,2176,San Diego | CA,TRUE
-San Diego,CA,158,Clifton Forebay,2190,San Diego | CA,TRUE
-San Diego,CA,158,Diamond Valley Lake,2191,San Diego | CA,TRUE
-San Diego,CA,158,El Capitan Lake,2164,San Diego | CA,TRUE
-San Diego,CA,158,Folsom Lake,2177,San Diego | CA,TRUE
-San Diego,CA,158,Hodges Reservoir,2168,San Diego | CA,TRUE
-San Diego,CA,158,Lake Mathews,2181,San Diego | CA,TRUE
-San Diego,CA,158,Lake Miramar,2162,San Diego | CA,TRUE
-San Diego,CA,158,Lake Oroville,2183,San Diego | CA,TRUE
-San Diego,CA,158,Lewiston Lake,2189,San Diego | CA,TRUE
-San Diego,CA,158,Little Panoche Reservoir,2186,San Diego | CA,TRUE
-San Diego,CA,158,Los Banos Reservoir,2185,San Diego | CA,TRUE
-San Diego,CA,158,Lower Otay Lake,2165,San Diego | CA,TRUE
-San Diego,CA,158,Morena Reservoir,2171,San Diego | CA,FALSE
-San Diego,CA,158,Murray Reservoir,2163,San Diego | CA,TRUE
-San Diego,CA,158,New Melones Lake,2184,San Diego | CA,TRUE
-San Diego,CA,158,Perris Reservoir,2179,San Diego | CA,TRUE
-San Diego,CA,158,Pyramid Lake,2188,San Diego | CA,TRUE
-San Diego,CA,158,Quail Lake,2187,San Diego | CA,FALSE
-San Diego,CA,158,San Luis Reservoir,2175,San Diego | CA,TRUE
-San Diego,CA,158,San Vicente Reservoir,2167,San Diego | CA,TRUE
-San Diego,CA,158,Shasta Lake,2172,San Diego | CA,TRUE
-San Diego,CA,158,Silverwood Lake,2182,San Diego | CA,TRUE
-San Diego,CA,158,Skinner Reservoir,2180,San Diego | CA,TRUE
-San Diego,CA,158,Sutherland Reservoir,2169,San Diego | CA,FALSE
-San Diego,CA,158,Trinity Lake,2174,San Diego | CA,FALSE
-San Diego,CA,158,Upper Otay Lake,2166,San Diego | CA,FALSE
-San Diego,CA,158,Whiskeytown Lake,2173,San Diego | CA,TRUE
-San Francisco,CA,166,Don Pedro Reservoir,2282,San Francisco | CA,TRUE
-San Francisco,CA,166,Moccasin Reservoir,2281,San Francisco | CA,FALSE
-San Francisco,CA,166,San Andreas Lake,2280,San Francisco | CA,TRUE
-San Jose,CA,163,Almaden Reservoir,2262,San Jose | CA,TRUE
-San Jose,CA,163,Anderson Lake,2260,San Jose | CA,TRUE
-San Jose,CA,163,Calaveras Reservoir,2253,San Jose | CA,TRUE
-San Jose,CA,163,Calero Reservoir,2261,San Jose | CA,TRUE
-San Jose,CA,163,Cherry Lake,2254,San Jose | CA,TRUE
-San Jose,CA,163,Chesbro Reservoir,2264,San Jose | CA,TRUE
-San Jose,CA,163,Coyote Lake,2263,San Jose | CA,FALSE
-San Jose,CA,163,Gilroy-Hollister Valley Basin,2271,San Jose | CA,FALSE
-San Jose,CA,163,Guadalupe Reservoir,2265,San Jose | CA,TRUE
-San Jose,CA,163,Hetch Hetchy Reservoir,2252,San Jose | CA,TRUE
-San Jose,CA,163,Lake del Valle,2251,San Jose | CA,TRUE
-San Jose,CA,163,Lake Eleanor,2255,San Jose | CA,TRUE
-San Jose,CA,163,Lake Elsman,2272,San Jose | CA,FALSE
-San Jose,CA,163,Lexington Reservoir,2266,San Jose | CA,FALSE
-San Jose,CA,163,Lower Crystal Springs Reservoir,2256,San Jose | CA,TRUE
-San Jose,CA,163,Pilarcitos Lake,2258,San Jose | CA,TRUE
-San Jose,CA,163,Priest Reservoir,2259,San Jose | CA,TRUE
-San Jose,CA,163,San Antonio Reservoir,2250,San Jose | CA,TRUE
-San Jose,CA,163,Santa Clara Valley Basin,2270,San Jose | CA,FALSE
-San Jose,CA,163,Santa Clara Valley Basin - SCVWD Wells,2529,San Jose | CA,FALSE
-San Jose,CA,163,Stevens Creek Reservoir,2269,San Jose | CA,TRUE
-San Jose,CA,163,Upper Crystal Springs Reservoir,2257,San Jose | CA,FALSE
-San Jose,CA,163,Uvas Reservoir,2267,San Jose | CA,TRUE
-San Jose,CA,163,Vasona Reservoir,2268,San Jose | CA,TRUE
-Santa Ana,CA,188,Orange County Basin,2359,Santa Ana | CA,TRUE
-Santa Barbara,CA,302,Bradbury Dam,3241,Santa Barbara | CA,TRUE
-Santa Barbara,CA,302,Gibraltar Reservoir,3369,Santa Barbara | CA,FALSE
-Santa Barbara,CA,302,Santa Barbara GW,3768,Santa Barbara | CA,FALSE
-Santa Clarita,CA,303,Santa Clarita GW,3770,Santa Clarita | CA,TRUE
-Santa Clarita,CA,303,Saugus Formation,3776,Santa Clarita | CA,TRUE
-Santa Cruz,CA,304,Laguna Creek,4057,Santa Cruz | CA,TRUE
-Santa Cruz,CA,304,Loch Lomond Reservoir,3566,Santa Cruz | CA,FALSE
-Santa Cruz,CA,304,Majors Creek,3655,Santa Cruz | CA,FALSE
-Santa Cruz,CA,304,Purisima Aquifer,3715,Santa Cruz | CA,FALSE
-Santa Cruz,CA,304,San Lorenzo River,3763,Santa Cruz | CA,TRUE
-Santa Fe,NM,561,McClure Reservoir,4246,Santa Fe | NM,FALSE
-Santa Fe,NM,561,Nichols Reservoir,4247,Santa Fe | NM,TRUE
-Santa Fe,NM,561,Rio Grande - Buckman Diversion,4248,Santa Fe | NM,TRUE
-Santa Fe,NM,561,Santa Fe Groundwater,4249,Santa Fe | NM,FALSE
-Santa Maria,CA,305,Santa Maria GW,3773,Santa Maria | CA,TRUE
-Santa Rosa,CA,306,Lake Mendocino,3502,Santa Rosa | CA,FALSE
-Santa Rosa,CA,306,Lake Pillsbury,3518,Santa Rosa | CA,TRUE
-Santa Rosa,CA,306,Lake Sonoma,3529,Santa Rosa | CA,FALSE
-Santa Rosa,CA,306,Russian River Alluvial Aquifer,3745,Santa Rosa | CA,FALSE
-Santa Rosa,CA,306,Russian River to Mirabel Dam,4053,Santa Rosa | CA,TRUE
-Santa Rosa,CA,306,Santa Rosa Plain GW,3774,Santa Rosa | CA,FALSE
-Savannah,GA,336,NA,NA,Savannah | GA,TRUE
-Scranton,PA,426,Griffin Reservoir,3381,Scranton | PA,TRUE
-Scranton,PA,426,Lake Scranton Reservoir,3527,Scranton | PA,TRUE
-Scranton,PA,426,Summit Lake Reservoir,3823,Scranton | PA,TRUE
-Seattle,WA,174,Cedar River - Landsburg diversion dam,2305,Seattle | WA,TRUE
-Seattle,WA,174,South Fork Tolt Reservoir,2306,Seattle | WA,TRUE
-Shreveport,LA,364,Cross Lake,3305,Shreveport | LA,TRUE
-Shreveport,LA,364,Twelve Mile Bayou,3844,Shreveport | LA,TRUE
-Simi Valley,CA,307,Simi Valley GW Basin,3793,Simi Valley | CA,TRUE
-Sioux City,IA,343,Dakota Sandstone Aquifer - Sioux City,3313,Sioux City | IA,FALSE
-Sioux City,IA,343,Missouri River Alluvial Aquifer,3623,Sioux City | IA,TRUE
-Sioux Falls,SD,433,Big Sioux Aquifer,3224,Sioux Falls | SD,FALSE
-Sioux Falls,SD,433,Big Sioux River,3225,Sioux Falls | SD,TRUE
-Sioux Falls,SD,433,Middle Skunk Creek Aquifer,3611,Sioux Falls | SD,FALSE
-Sioux Falls,SD,433,Split Rock Creek Aquifer,3807,Sioux Falls | SD,FALSE
-South Bend,IN,353,Hilltop Aquifer,3396,South Bend | IN,TRUE
-South Bend,IN,353,St. Joseph Aquifer,3812,South Bend | IN,TRUE
-Spartanburg,SC,432,Lake Blalock,3452,Spartanburg | SC,TRUE
-Spartanburg,SC,432,Lake Bowen,3454,Spartanburg | SC,FALSE
-Spartanburg,SC,432,Municipal Reservoir No. 1,3638,Spartanburg | SC,FALSE
-Spokane,WA,464,Spokane Valley Rathdrum Prairie Aquifer,3808,Spokane | WA,TRUE
-Springfield,IL,348,Lake Springfield,3532,Springfield | IL,TRUE
-Springfield,IL,348,Sangamon River,3766,Springfield | IL,TRUE
-Springfield,MA,367,Cobble Mountain Reservoir,3293,Springfield | MA,TRUE
-Springfield,MO,379,Fellows Lake,3355,Springfield | MO,FALSE
-Springfield,MO,379,Fulbright Spring,3365,Springfield | MO,FALSE
-Springfield,MO,379,James River,3420,Springfield | MO,TRUE
-Springfield,MO,379,McDaniel Lake,3592,Springfield | MO,FALSE
-Springfield,MO,379,Springfield MO GW,3810,Springfield | MO,FALSE
-Springfield,MO,379,Stockton Lake,3818,Springfield | MO,TRUE
-Stockton,CA,308,New Hogan Reservoir,3649,Stockton | CA,TRUE
-Stockton,CA,308,San Joaquin Co. GW,3759,Stockton | CA,FALSE
-Stockton,CA,308,Stockton GW,3817,Stockton | CA,FALSE
-Syracuse,NY,407,Skaneateles Lake,3798,Syracuse | NY,TRUE
-Tallahassee,FL,331,Floridan Aquifer,3360,Tallahassee | FL,TRUE
-Tampa,FL,186,Alafia River,2344,Tampa | FL,TRUE
-Tampa,FL,186,Floridan Aquifer,2345,Tampa | FL,FALSE
-Tampa,FL,186,Hillsborough River,2343,Tampa | FL,TRUE
-Thousand Oaks,CA,309,Lake Oroville,2183,Thousand Oaks | CA,TRUE
-Toledo,OH,414,Lake Erie,3469,Toledo | OH,TRUE
-Topeka,KS,354,Kansas River,3427,Topeka | KS,TRUE
-Trenton,NJ,400,Delaware River,3316,Trenton | NJ,TRUE
-Tucson,AZ,288,Lake Havasu,3481,Tucson | AZ,TRUE
-Tucson,AZ,288,Tucson_GW,3841,Tucson | AZ,FALSE
-Tulsa,OK,417,Lake Eucha,3470,Tulsa | OK,FALSE
-Tulsa,OK,417,Lake Hudson,3486,Tulsa | OK,TRUE
-Tulsa,OK,417,Lake Oologah,3514,Tulsa | OK,TRUE
-Tulsa,OK,417,Lake Spavinaw,3530,Tulsa | OK,TRUE
-Tuscaloosa,AL,285,Harris Lake,3387,Tuscaloosa | AL,FALSE
-Tuscaloosa,AL,285,Lake Nicol,3509,Tuscaloosa | AL,FALSE
-Tuscaloosa,AL,285,Lake Tuscaloosa,3539,Tuscaloosa | AL,TRUE
-Tyler,TX,453,Carrizo-Wilcox Aquifer,3266,Tyler | TX,FALSE
-Tyler,TX,453,Lake Palestine,3516,Tyler | TX,TRUE
-Tyler,TX,453,Lake Tyler,3540,Tyler | TX,TRUE
-Tyler,TX,453,Lake Tyler East,3541,Tyler | TX,TRUE
-Utica,NY,408,Hinckley Reservoir,3397,Utica | NY,TRUE
-Vallejo,CA,310,Lake Frey,3474,Vallejo | CA,TRUE
-Vallejo,CA,310,Lake Madigan,3497,Vallejo | CA,FALSE
-Vallejo,CA,310,Sacramento River - North Bay aqueduct intake,3747,Vallejo | CA,TRUE
-Virginia Beach,VA,459,Lake Burnt Mills,3457,Virginia Beach | VA,FALSE
-Virginia Beach,VA,459,Lake Gaston,3476,Virginia Beach | VA,TRUE
-Virginia Beach,VA,459,Lake Prince,3520,Virginia Beach | VA,FALSE
-Virginia Beach,VA,459,Virginia Beach GW,3854,Virginia Beach | VA,FALSE
-Virginia Beach,VA,459,Western Branch Reservoir-VA,3868,Virginia Beach | VA,TRUE
-Visalia,CA,311,Visalia-GW,3855,Visalia | CA,TRUE
-Waco,TX,454,Lake Belton,3449,Waco | TX,TRUE
-Waco,TX,454,Lake Waco,3543,Waco | TX,TRUE
-Washington,D.C.,175,Potomac River - Dalecarlia Reservoir,2309,Washington | D.C.,TRUE
-Washington,D.C.,175,Potomac River - McMillan WTP,2310,Washington | D.C.,FALSE
-Waterbury,CT,318,Cairnes Reservoir,3254,Waterbury | CT,FALSE
-Waterbury,CT,318,Morris Reservoir,3633,Waterbury | CT,FALSE
-Waterbury,CT,318,Pitch Reservoir,3694,Waterbury | CT,FALSE
-Waterbury,CT,318,Shepaug Reservoir,3787,Waterbury | CT,TRUE
-Waterbury,CT,318,Wigwam Reservoir,3874,Waterbury | CT,TRUE
-Waterloo,IA,341,Cedar River Alluvial Aquifer - Waterloo,4035,Waterloo | IA,TRUE
-Waterloo,IA,341,Cedar Valley Aquifer,3275,Waterloo | IA,FALSE
-Wichita,KS,355,Cheney Reservoir,3281,Wichita | KS,TRUE
-Wichita,KS,355,Equus Beds- High Plains Aquifer,3345,Wichita | KS,FALSE
-Wilmington,NC,392,Cape Fear River - Wilmington,4034,Wilmington | NC,TRUE
-Wilmington,NC,392,Castle Hayne Aquifer,3269,Wilmington | NC,FALSE
-Winston-Salem,NC,393,Salem Lake,3750,Winston-Salem | NC,TRUE
-Winston-Salem,NC,393,Yadkin River - Winston-Salem,4052,Winston-Salem | NC,TRUE
-Winter Haven,FL,332,Floridan Aquifer,3360,Winter Haven | FL,TRUE
-Worcester,MA,368,Coal Mine Brook Well,3292,Worcester | MA,FALSE
-Worcester,MA,368,Holden Reservoir No. 1,3399,Worcester | MA,FALSE
-Worcester,MA,368,Holden Reservoir No. 2,3400,Worcester | MA,TRUE
-Worcester,MA,368,Kendal Reservoir,3428,Worcester | MA,FALSE
-Worcester,MA,368,Kettle Brook Reservoir No. 1,3433,Worcester | MA,FALSE
-Worcester,MA,368,Kettle Brook Reservoir No. 2,3434,Worcester | MA,FALSE
-Worcester,MA,368,Kettle Brook Reservoir No. 3,3435,Worcester | MA,FALSE
-Worcester,MA,368,Kettle Brook Reservoir No. 4,3436,Worcester | MA,FALSE
-Worcester,MA,368,Lynde Brook Reservoir,3578,Worcester | MA,TRUE
-Worcester,MA,368,Pine Hill Reservoir,3692,Worcester | MA,FALSE
-Worcester,MA,368,Quinapoxet Reservoir,4075,Worcester | MA,TRUE
-Worcester,MA,368,Shrewsbury Well,3789,Worcester | MA,FALSE
-Yakima,WA,463,Ellensburg Aquifer,3344,Yakima | WA,FALSE
-Yakima,WA,463,Naches River,3642,Yakima | WA,TRUE
-York,PA,427,Lake Redman,3523,York | PA,FALSE
-York,PA,427,Lake Williams,3546,York | PA,FALSE
-York,PA,427,Susquehanna River - York,4038,York | PA,TRUE
-Youngstown,OH,415,Meander Reservoir,3598,Youngstown | OH,TRUE
+city,state,city_uid,intake,DVSN_ID,DVTR_ID,city_state,key_watershed
+Abilene,TX,441,Ft. Phantom Hill Reservoir,3364,1386,Abilene | TX,FALSE
+Abilene,TX,441,Hubbard Creek Reservoir,3407,1386,Abilene | TX,TRUE
+Abilene,TX,441,Lake Abilene,3445,1386,Abilene | TX,TRUE
+Abilene,TX,441,Lake Kirby,3491,1386,Abilene | TX,TRUE
+Abilene,TX,441,Clear Fork Brazo River,3289,1386,Abilene | TX,TRUE
+Abilene,TX,441,Lake Ivie,3488,1386,Abilene | TX,TRUE
+Akron,OH,410,East Branch Reservoir-OH,3329,1355,Akron | OH,FALSE
+Akron,OH,410,Lake Rockwell,3526,1355,Akron | OH,TRUE
+Akron,OH,410,Wendell R LaDue Reservoir,3862,1355,Akron | OH,FALSE
+Albany,NY,404,Alcove Reservoir,3176,1349,Albany | NY,TRUE
+Albany,NY,404,Basic Creek Reservoir,3210,1349,Albany | NY,TRUE
+Albuquerque,NM,401,NA,3771,1346,Albuquerque | NM,FALSE
+Albuquerque,NM,401,Rio Grande - Albuquerque,4045,1346,Albuquerque | NM,TRUE
+Amarillo,TX,442,NA,3666,1387,Amarillo | TX,FALSE
+Amarillo,TX,442,Lake Meredith-TX,3504,1387,Amarillo | TX,TRUE
+Ann Arbor,MI,371,NA,3187,1316,Ann Arbor | MI,FALSE
+Ann Arbor,MI,371,Barton Pond,3209,1316,Ann Arbor | MI,TRUE
+Antioch,CA,289,Contra Loma Reservoir,3301,1235,Antioch | CA,FALSE
+Antioch,CA,289,Los Vaqueros Reservoir,3571,1235,Antioch | CA,FALSE
+Antioch,CA,289,Mallard Reservoir,3581,1235,Antioch | CA,TRUE
+Antioch,CA,289,Martinez Reservoir,3589,1235,Antioch | CA,TRUE
+Antioch,CA,289,San Joaquin River,3760,1235,Antioch | CA,TRUE
+Antioch,CA,289,Clifton Forebay,2190,1235,Antioch | CA,FALSE
+Antioch,CA,289,Lewiston Lake,2189,1235,Antioch | CA,TRUE
+Appleton,WI,465,Lake Winnebago,3547,1410,Appleton | WI,TRUE
+Asheville,NC,383,Bee Tree Reservoir,3216,1328,Asheville | NC,TRUE
+Asheville,NC,383,North Fork Reservoir,3656,1328,Asheville | NC,TRUE
+Asheville,NC,383,Mills River,3616,1328,Asheville | NC,TRUE
+Athens,GA,334,Bear Creek Reservoir- Gaz,3214,1280,Athens | GA,TRUE
+Athens,GA,334,Middle Oconee River,3610,1280,Athens | GA,TRUE
+Athens,GA,334,North Oconee River,3657,1280,Athens | GA,TRUE
+Atlanta,GA,181,Chattahoochee River,2331,1055,Atlanta | GA,TRUE
+Atlantic City,NJ,399,NA,3295,1344,Atlantic City | NJ,FALSE
+Atlantic City,NJ,399,NA,3438,1344,Atlantic City | NJ,FALSE
+Atlantic City,NJ,399,Doughty Pond Dam,3325,1344,Atlantic City | NJ,TRUE
+Atlantic City,NJ,399,Kuehnle Pond Dam,3440,1344,Atlantic City | NJ,FALSE
+Augusta-Richmond,GA,337,NA,3304,1283,Augusta-Richmond | GA,FALSE
+Augusta-Richmond,GA,337,Savannah River,3777,1283,Augusta-Richmond | GA,TRUE
+Aurora,CO,187,Strontia Springs Reservoir,2317,1062,Aurora | CO,TRUE
+Aurora,CO,187,NA,2347,1062,Aurora | CO,FALSE
+Aurora,CO,187,Aurora Reservoir,2348,1062,Aurora | CO,TRUE
+Aurora,CO,187,Quincy Reservoir,2349,1062,Aurora | CO,TRUE
+Aurora,CO,187,Spinney Mountain Reservoir,2350,1062,Aurora | CO,FALSE
+Aurora,CO,187,Jefferson Reservoir,2351,1062,Aurora | CO,FALSE
+Aurora,CO,187,Rampart Reservoir,2352,1062,Aurora | CO,TRUE
+Aurora,CO,187,Turquoise Lake,2353,1062,Aurora | CO,FALSE
+Aurora,CO,187,Twin Lakes,2354,1062,Aurora | CO,FALSE
+Aurora,CO,187,Pueblo Reservoir,2355,1062,Aurora | CO,TRUE
+Aurora,CO,187,Lake Henry,2356,1062,Aurora | CO,FALSE
+Aurora,CO,187,Lake Meredith,2357,1062,Aurora | CO,TRUE
+Aurora,CO,187,Homestake Reservoir,2358,1062,Aurora | CO,TRUE
+Austin,TX,167,Colorado River (TX) - Albert R. Davis WTP,2283,1041,Austin | TX,FALSE
+Austin,TX,167,Colorado River (TX) - Albert H. Ullrich WTP,2284,1041,Austin | TX,TRUE
+Bakersfield,CA,290,NA,3203,1236,Bakersfield | CA,FALSE
+Bakersfield,CA,290,Kern River,3432,1236,Bakersfield | CA,TRUE
+Bakersfield,CA,290,Clifton Forebay,2190,1236,Bakersfield | CA,TRUE
+Bakersfield,CA,290,Lewiston Lake,2189,1236,Bakersfield | CA,TRUE
+Baltimore,MD,172,Loch Raven Reservoir,2298,1046,Baltimore | MD,TRUE
+Baltimore,MD,172,Liberty Reservoir,2299,1046,Baltimore | MD,TRUE
+Baltimore,MD,172,Prettyboy Reservoir,2300,1046,Baltimore | MD,FALSE
+Baltimore,MD,172,Conowingo Dam – Susquehanna River,2301,1046,Baltimore | MD,TRUE
+Barnstable,MA,365,NA,4072,1310,Barnstable | MA,TRUE
+Baton Rouge,LA,358,NA,3804,1303,Baton Rouge | LA,TRUE
+Beaumont,TX,443,Neches River,3644,1388,Beaumont | TX,TRUE
+Beaumont,TX,443,NA,2140,1388,Beaumont | TX,FALSE
+Berkeley,CA,555,Briones Reservoir,2335,1058,Berkeley | CA,TRUE
+Berkeley,CA,555,Pardee Reservoir,2339,1058,Berkeley | CA,FALSE
+Berkeley,CA,555,Camanche Reservoir,2340,1058,Berkeley | CA,TRUE
+Billings,MT,382,Yellowstone River,3883,1327,Billings | MT,TRUE
+Binghamton,NY,409,Susquehanna River - Binghampton,4036,1354,Binghamton | NY,TRUE
+Birmingham,AL,281,Inland Lake,3415,1227,Birmingham | AL,TRUE
+Birmingham,AL,281,Lake Purdy,3521,1227,Birmingham | AL,TRUE
+Birmingham,AL,281,Cahaba River,3253,1227,Birmingham | AL,TRUE
+Birmingham,AL,281,Mulberry Fork,3637,1227,Birmingham | AL,FALSE
+Birmingham,AL,281,Sipsey Fork,3796,1227,Birmingham | AL,TRUE
+Boise,ID,344,NA,3234,1289,Boise | ID,FALSE
+Boise,ID,344,Boise River,3235,1289,Boise | ID,TRUE
+Boston,MA,173,Quabbin Reservoir,2302,1047,Boston | MA,TRUE
+Boston,MA,173,Wachusett Reservoir,2303,1047,Boston | MA,TRUE
+Boston,MA,173,Ware River,2304,1047,Boston | MA,TRUE
+Boulder,CO,312,Barker Reservoir,3205,1258,Boulder | CO,TRUE
+Boulder,CO,312,Boulder Reservoir,3238,1258,Boulder | CO,TRUE
+Boulder,CO,312,Silver Lake,3790,1258,Boulder | CO,FALSE
+Boulder,CO,312,Lakewood Reservoir,4030,1258,Boulder | CO,TRUE
+Boulder,CO,312,Green Mountain Dam,3380,1258,Boulder | CO,TRUE
+Boulder,CO,312,Windy Gap Reservoir,3880,1258,Boulder | CO,TRUE
+Boulder,CO,312,Willow Creek Dam,3878,1258,Boulder | CO,FALSE
+Boulder,CO,312,Granby Reservoir,3375,1258,Boulder | CO,FALSE
+Boulder,CO,312,Shadow Mountain Dam,3785,1258,Boulder | CO,FALSE
+Boulder,CO,312,Olympus Dam,3670,1258,Boulder | CO,TRUE
+Boulder,CO,312,Flat Iron Dam,3357,1258,Boulder | CO,TRUE
+Boulder,CO,312,Carter Lake,4033,1258,Boulder | CO,TRUE
+Bremerton,WA,461,NA,3242,1406,Bremerton | WA,FALSE
+Bremerton,WA,461,Union River Reservoir,3849,1406,Bremerton | WA,TRUE
+Bridgeport,CT,512,Saugatuck Reservoir,4078,1456,Bridgeport | CT,TRUE
+Bridgeport,CT,512,Easton Reservoir,4079,1456,Bridgeport | CT,TRUE
+Bridgeport,CT,512,Hemlocks Reservoir,4080,1456,Bridgeport | CT,TRUE
+Bridgeport,CT,512,Trap Fall Reservoir,4081,1456,Bridgeport | CT,TRUE
+Bridgeport,CT,512,Aspetuck Reservoir,4082,1456,Bridgeport | CT,FALSE
+Bridgeport,CT,512,Far Mill Reservoir,4083,1456,Bridgeport | CT,FALSE
+Bridgeport,CT,512,West Pequonnock Reservoir,4084,1456,Bridgeport | CT,TRUE
+Bridgeport,CT,512,Means Brook Reservoir,4085,1456,Bridgeport | CT,TRUE
+Brooksville,FL,320,NA,4071,1266,Brooksville | FL,TRUE
+Brownsville,TX,444,Amistad Dam,3185,1389,Brownsville | TX,FALSE
+Brownsville,TX,444,Falcon Dam,3348,1389,Brownsville | TX,TRUE
+Buffalo,NY,405,Lake Erie,3469,1350,Buffalo | NY,TRUE
+Burlington,VT,460,Lake Champlain,3459,1405,Burlington | VT,TRUE
+Canton,OH,411,NA,3262,1356,Canton | OH,TRUE
+Cape Coral,FL,321,NA,3575,1267,Cape Coral | FL,TRUE
+Cedar Rapids,IA,339,Cedar River Alluvial Aquifer - Cedar Rapids,3273,1284,Cedar Rapids | IA,TRUE
+Champaign,IL,345,NA,3370,1290,Champaign | IL,TRUE
+Champaign,IL,345,NA,3580,1290,Champaign | IL,TRUE
+Charleston,WV,471,Elk River,3342,1416,Charleston | WV,TRUE
+Charlotte,NC,170,Mountain Island Lake,2295,1044,Charlotte | NC,TRUE
+Charlotte,NC,170,Lake Norman,2296,1044,Charlotte | NC,FALSE
+Chattanooga,TN,438,Tennessee River - Chattanooga,4050,1383,Chattanooga | TN,TRUE
+Chicago,IL,160,Lake Michigan,3506,1033,Chicago | IL,TRUE
+Cincinnati,OH,413,NA,3377,1358,Cincinnati | OH,FALSE
+Cincinnati,OH,413,Ohio River - Cincinnati,3668,1358,Cincinnati | OH,TRUE
+Clarksville,TN,439,Cumberland River - Clarksville,4039,1384,Clarksville | TN,TRUE
+Cleveland,OH,183,Lake Erie,3469,1057,Cleveland | OH,TRUE
+Colorado Springs,CO,313,Big Horn Reservoir,3223,1259,Colorado Springs | CO,FALSE
+Colorado Springs,CO,313,Big Tooth Reservoir,3226,1259,Colorado Springs | CO,TRUE
+Colorado Springs,CO,313,Boehmer Reservoir,3231,1259,Colorado Springs | CO,FALSE
+Colorado Springs,CO,313,Clear Creek Reservoir,3288,1259,Colorado Springs | CO,FALSE
+Colorado Springs,CO,313,Crystal Creek Reservoir-CO,3308,1259,Colorado Springs | CO,TRUE
+Colorado Springs,CO,313,Grizzly Reservoir,3383,1259,Colorado Springs | CO,TRUE
+Colorado Springs,CO,313,Homestake Reservoir,2358,1259,Colorado Springs | CO,TRUE
+Colorado Springs,CO,313,Lake Henry,2356,1259,Colorado Springs | CO,FALSE
+Colorado Springs,CO,313,Lake Meredith,2357,1259,Colorado Springs | CO,TRUE
+Colorado Springs,CO,313,Lake Moraine,3507,1259,Colorado Springs | CO,FALSE
+Colorado Springs,CO,313,Mason Reservoir,3590,1259,Colorado Springs | CO,FALSE
+Colorado Springs,CO,313,McReynolds Reservoir,3596,1259,Colorado Springs | CO,FALSE
+Colorado Springs,CO,313,Montgomery Reservoir,3629,1259,Colorado Springs | CO,TRUE
+Colorado Springs,CO,313,Nichols Reservoir,3651,1259,Colorado Springs | CO,FALSE
+Colorado Springs,CO,313,North Catamount Reservoir,3654,1259,Colorado Springs | CO,FALSE
+Colorado Springs,CO,313,Northfield Reservoir,3660,1259,Colorado Springs | CO,FALSE
+Colorado Springs,CO,313,Pikeview Reservoir,3689,1259,Colorado Springs | CO,TRUE
+Colorado Springs,CO,313,Pueblo Reservoir,2355,1259,Colorado Springs | CO,TRUE
+Colorado Springs,CO,313,Rampart Reservoir,2352,1259,Colorado Springs | CO,FALSE
+Colorado Springs,CO,313,Rosemont Reservoir,3742,1259,Colorado Springs | CO,FALSE
+Colorado Springs,CO,313,Ruedi Reservoir,3744,1259,Colorado Springs | CO,TRUE
+Colorado Springs,CO,313,South Catamount Reservoir,3801,1259,Colorado Springs | CO,FALSE
+Colorado Springs,CO,313,Turquoise Lake,2353,1259,Colorado Springs | CO,FALSE
+Colorado Springs,CO,313,Twin Lakes,2354,1259,Colorado Springs | CO,FALSE
+Colorado Springs,CO,313,Upper Blue Reservoir,3850,1259,Colorado Springs | CO,TRUE
+Colorado Springs,CO,313,Wilson Reservoir,3879,1259,Colorado Springs | CO,FALSE
+Columbia,SC,429,Broad River Diversion Canal,3244,1374,Columbia | SC,TRUE
+Columbia,SC,429,Lake Murray,3508,1374,Columbia | SC,FALSE
+Columbus,OH,168,Griggs Reservoir - dammed Scioto R.,2285,1042,Columbus | OH,TRUE
+Columbus,OH,168,O'Shaughnessy Reservoir - dammed Scioto R.,2286,1042,Columbus | OH,FALSE
+Columbus,OH,168,Hoover Reservoir,2287,1042,Columbus | OH,TRUE
+Columbus,OH,168,NA,2288,1042,Columbus | OH,FALSE
+Concord,CA,291,Contra Loma Reservoir,3301,1237,Concord | CA,TRUE
+Concord,CA,291,Los Vaqueros Reservoir,3571,1237,Concord | CA,TRUE
+Concord,CA,291,Mallard Reservoir,3581,1237,Concord | CA,TRUE
+Concord,CA,291,Martinez Reservoir,3589,1237,Concord | CA,TRUE
+Concord,CA,291,Clifton Forebay,2190,1237,Concord | CA,TRUE
+Concord,CA,291,Lewiston Lake,2189,1237,Concord | CA,TRUE
+Concord,NC,384,Kannapolis Lake,3425,1329,Concord | NC,TRUE
+Concord,NC,384,Lake Concord,3460,1329,Concord | NC,TRUE
+Concord,NC,384,Lake Don T. Howell,3466,1329,Concord | NC,TRUE
+Concord,NC,384,Lake Fisher,3472,1329,Concord | NC,FALSE
+Concord,NC,384,Lake Norman,2296,1329,Concord | NC,FALSE
+Concord,NC,384,Mountain Island Lake,2295,1329,Concord | NC,TRUE
+Corpus Christi,TX,445,Choke Canyon Reservoir,3286,1390,Corpus Christi | TX,FALSE
+Corpus Christi,TX,445,Lake Corpus Christi,3462,1390,Corpus Christi | TX,TRUE
+Corpus Christi,TX,445,Lake Texana,3536,1390,Corpus Christi | TX,TRUE
+Dallas,TX,159,Elm Fork of the Trinity River - Elm Fork WTP,2192,1032,Dallas | TX,TRUE
+Dallas,TX,159,Ray Roberts Lake,2193,1032,Dallas | TX,FALSE
+Dallas,TX,159,Lewisville Lake,2194,1032,Dallas | TX,FALSE
+Dallas,TX,159,Grapevine Lake,2195,1032,Dallas | TX,FALSE
+Dallas,TX,159,Ray Hubbard Lake,2196,1032,Dallas | TX,TRUE
+Dallas,TX,159,Tawakoni Lake,2197,1032,Dallas | TX,TRUE
+Dallas,TX,159,Fork Lake,2198,1032,Dallas | TX,TRUE
+Danbury,CT,319,NA,3429,1265,Danbury | CT,FALSE
+Danbury,CT,319,NA,3672,1265,Danbury | CT,FALSE
+Danbury,CT,319,East Lake,3332,1265,Danbury | CT,FALSE
+Danbury,CT,319,Lower Kohanza Reservoir,3576,1265,Danbury | CT,TRUE
+Danbury,CT,319,Margerie Reservoir,3585,1265,Danbury | CT,FALSE
+Danbury,CT,319,Padanaram Reservoir,3678,1265,Danbury | CT,TRUE
+Danbury,CT,319,Upper Kohanza Reservoir,3851,1265,Danbury | CT,FALSE
+Danbury,CT,319,West Lake,3865,1265,Danbury | CT,FALSE
+Davenport,IA,342,Mississippi River - Davenport,3621,1287,Davenport | IA,TRUE
+Dayton,OH,412,NA,3607,1357,Dayton | OH,TRUE
+Deltona,FL,322,NA,3360,1268,Deltona | FL,TRUE
+Denver,CO,176,Dillon Reservoir,2311,1050,Denver | CO,TRUE
+Denver,CO,176,Tributaries to Fraser River (Moffat Tunnel),2312,1050,Denver | CO,TRUE
+Denver,CO,176,Antero Reservoir,2313,1050,Denver | CO,FALSE
+Denver,CO,176,Eleven Mile Canyon Reservoir,2314,1050,Denver | CO,FALSE
+Denver,CO,176,Cheesman Reservoir,2315,1050,Denver | CO,FALSE
+Denver,CO,176,Gross Reservoir,2316,1050,Denver | CO,TRUE
+Denver,CO,176,Strontia Springs Reservoir,2317,1050,Denver | CO,TRUE
+Denver,CO,176,Bear Creek (to canal),2318,1050,Denver | CO,TRUE
+Denver,CO,176,Ralston Reservoir,2319,1050,Denver | CO,TRUE
+Denver,CO,176,Williams Fork River intake,2320,1050,Denver | CO,TRUE
+Des Moines,IA,340,Des Moines River,3318,1285,Des Moines | IA,TRUE
+Des Moines,IA,340,Raccoon River,3721,1285,Des Moines | IA,TRUE
+Des Moines,IA,340,Raccoon River Alluvial Aquifer,3722,1285,Des Moines | IA,FALSE
+Detroit,MI,171,Lake Huron,3487,1045,Detroit | MI,FALSE
+Detroit,MI,171,Detroit River,2307,1045,Detroit | MI,TRUE
+Detroit,MI,171,Lake St. Clair - 3 WTP intakes,2308,1045,Detroit | MI,FALSE
+Duluth,MN,378,Lake Superior,3533,1323,Duluth | MN,TRUE
+Durham,NC,385,Lake Jordan,3489,1330,Durham | NC,TRUE
+Durham,NC,385,Lake Michie,3505,1330,Durham | NC,TRUE
+Durham,NC,385,Little River Reservoir,3562,1330,Durham | NC,TRUE
+El Paso,TX,455,NA,3409,1400,El Paso | TX,FALSE
+El Paso,TX,455,NA,3606,1400,El Paso | TX,FALSE
+El Paso,TX,455,Rio Grande River - El Paso,3733,1400,El Paso | TX,TRUE
+Elkhart,IN,352,NA,3343,1297,Elkhart | IN,TRUE
+Erie,PA,421,Lake Erie,3469,1366,Erie | PA,TRUE
+Eugene,OR,418,McKenzie River,3595,1363,Eugene | OR,TRUE
+Evansville,IN,351,Ohio River - Evansville,4042,1296,Evansville | IN,TRUE
+Fairfield,CA,292,Lake Berryessa,3451,1238,Fairfield | CA,FALSE
+Fairfield,CA,292,Lake Oroville,2183,1238,Fairfield | CA,TRUE
+Fairfield,CA,292,Sacramento River - North Bay aqueduct intake,3747,1238,Fairfield | CA,TRUE
+Fargo,ND,394,Red River,3727,1339,Fargo | ND,TRUE
+Fayetteville,NC,386,Bonnie Doone Lake,3237,1331,Fayetteville | NC,FALSE
+Fayetteville,NC,386,Glenville Lake,3372,1331,Fayetteville | NC,TRUE
+Fayetteville,NC,386,Kornbow Lake,3439,1331,Fayetteville | NC,FALSE
+Fayetteville,NC,386,Mintz Pond,3617,1331,Fayetteville | NC,FALSE
+Fayetteville,NC,386,Cape Fear River - Fayetteville,3264,1331,Fayetteville | NC,TRUE
+Flint,MI,372,Lake Huron,3487,1317,Flint | MI,FALSE
+Flint,MI,372,Detroit River,2307,1317,Flint | MI,TRUE
+Fort Collins,CO,314,Flat Iron Dam,3357,1260,Fort Collins | CO,TRUE
+Fort Collins,CO,314,Granby Reservoir,3375,1260,Fort Collins | CO,FALSE
+Fort Collins,CO,314,Green Mountain Dam,3380,1260,Fort Collins | CO,TRUE
+Fort Collins,CO,314,Horsetooth Reservoir,3405,1260,Fort Collins | CO,TRUE
+Fort Collins,CO,314,Olympus Dam,3670,1260,Fort Collins | CO,TRUE
+Fort Collins,CO,314,Shadow Mountain Dam,3785,1260,Fort Collins | CO,FALSE
+Fort Collins,CO,314,Willow Creek Dam,3878,1260,Fort Collins | CO,FALSE
+Fort Collins,CO,314,Cache La Poudre River,3252,1260,Fort Collins | CO,TRUE
+Fort Collins,CO,314,Michigan River,4031,1260,Fort Collins | CO,TRUE
+Fort Collins,CO,314,Joe Wright Reservoir,4032,1260,Fort Collins | CO,FALSE
+Fort Collins,CO,314,Windy Gap Reservoir,3880,1260,Fort Collins | CO,TRUE
+Fort Smith,AR,287,Lake Fort Smith,3473,1233,Fort Smith | AR,TRUE
+Fort Smith,AR,287,Lee Creek Reservoir,3553,1233,Fort Smith | AR,TRUE
+Fort Walton Beach,FL,323,NA,3360,1269,Fort Walton Beach | FL,TRUE
+Fort Wayne,IN,349,Cedarville Dam,3276,1294,Fort Wayne | IN,FALSE
+Fort Wayne,IN,349,Hurshtown Reservoir,3411,1294,Fort Wayne | IN,FALSE
+Fort Wayne,IN,349,St. Joseph River,3653,1294,Fort Wayne | IN,TRUE
+Fort Worth,TX,169,Lake Bridgeport,2289,1043,Fort Worth | TX,FALSE
+Fort Worth,TX,169,Eagle Mountain Lake,2290,1043,Fort Worth | TX,FALSE
+Fort Worth,TX,169,Lake Worth,2291,1043,Fort Worth | TX,TRUE
+Fort Worth,TX,169,Benbrook Lake,2292,1043,Fort Worth | TX,TRUE
+Fort Worth,TX,169,Cedar Creek Reservoir,2293,1043,Fort Worth | TX,TRUE
+Fort Worth,TX,169,Richland-Chambers Reservoir,2294,1043,Fort Worth | TX,TRUE
+Frederick,MD,369,Fishing Creek Reservoir,3356,1314,Frederick | MD,FALSE
+Frederick,MD,369,Linganore Creek Reservoir,3559,1314,Frederick | MD,TRUE
+Frederick,MD,369,Monocacy River,3628,1314,Frederick | MD,TRUE
+Frederick,MD,369,Potomac River - Fredrick,3703,1314,Frederick | MD,TRUE
+Fresno,CA,293,NA,3363,1239,Fresno | CA,FALSE
+Fresno,CA,293,Millerton Lake,3614,1239,Fresno | CA,TRUE
+Fresno,CA,293,Pine Flat Lake,3691,1239,Fresno | CA,TRUE
+Gainesville,FL,324,NA,3360,1270,Gainesville | FL,TRUE
+Gastonia,NC,387,Mountain Island Lake,2295,1332,Gastonia | NC,TRUE
+Grand Rapids,MI,373,Lake Michigan,3506,1318,Grand Rapids | MI,TRUE
+Green Bay,WI,466,NA,3379,1411,Green Bay | WI,FALSE
+Green Bay,WI,466,Lake Michigan,3506,1411,Green Bay | WI,TRUE
+Greensboro,NC,388,Lake Brandt,3455,1333,Greensboro | NC,FALSE
+Greensboro,NC,388,Lake Higgins,3484,1333,Greensboro | NC,FALSE
+Greensboro,NC,388,Lake Mackintosh,3496,1333,Greensboro | NC,TRUE
+Greensboro,NC,388,Lake Reidsville,3524,1333,Greensboro | NC,TRUE
+Greensboro,NC,388,Lake Townsend,3538,1333,Greensboro | NC,TRUE
+Greensboro,NC,388,Salem Lake,3750,1333,Greensboro | NC,FALSE
+Greensboro,NC,388,Stoney Creek Reservoir,3819,1333,Greensboro | NC,TRUE
+Greensboro,NC,388,Yadkin River - Greensboro,3882,1333,Greensboro | NC,TRUE
+Greenville,SC,430,Lake Keowee,3490,1375,Greenville | SC,TRUE
+Greenville,SC,430,Poinsett Reservoir,3698,1375,Greenville | SC,TRUE
+Greenville,SC,430,Table Rock Reservoir,3829,1375,Greenville | SC,TRUE
+Hagerstown,MD,370,Edgemeont Reservoir,3336,1315,Hagerstown | MD,TRUE
+Hagerstown,MD,370,Potomac River - Hagerstown,4054,1315,Hagerstown | MD,TRUE
+Harlingen,TX,446,Rio Grande - Harlingen,4046,1391,Harlingen | TX,TRUE
+Harrisburg,PA,422,Stony Creek,3821,1367,Harrisburg | PA,FALSE
+Harrisburg,PA,422,Swatara Creek,3827,1367,Harrisburg | PA,TRUE
+Harrisburg,PA,422,Susquehanna River - Harrisburg,4037,1367,Harrisburg | PA,TRUE
+Hartford,CT,316,Barkhamsted Reservoir,3206,1262,Hartford | CT,FALSE
+Hartford,CT,316,Nepaug Reservoir,3645,1262,Hartford | CT,TRUE
+Hemet,CA,294,NA,3391,1240,Hemet | CA,TRUE
+Hemet,CA,294,NA,3758,1240,Hemet | CA,TRUE
+Hickory,NC,389,Lake Hickory,3483,1334,Hickory | NC,TRUE
+Hickory,NC,389,Lake Rhodhiss,3525,1334,Hickory | NC,FALSE
+High Point,NC,390,City Lake,3287,1335,High Point | NC,TRUE
+High Point,NC,390,Oak Hollow,3663,1335,High Point | NC,FALSE
+Houma,LA,359,Bayou Lafourche,3213,1304,Houma | LA,TRUE
+Houma,LA,359,Gulf Intercoastal Waterway,3386,1304,Houma | LA,TRUE
+Houston,TX,154,NA,2139,1025,Houston | TX,FALSE
+Houston,TX,154,NA,2140,1025,Houston | TX,FALSE
+Houston,TX,154,Lake Livingston,2141,1025,Houston | TX,TRUE
+Houston,TX,154,Lake Conroe,2142,1025,Houston | TX,FALSE
+Houston,TX,154,Lake Houston,2143,1025,Houston | TX,TRUE
+Huntington,WV,472,Ohio River - Huntington,4044,1417,Huntington | WV,TRUE
+Huntsville,AL,282,NA,3410,1228,Huntsville | AL,FALSE
+Huntsville,AL,282,Tennessee River - Huntsville,3834,1228,Huntsville | AL,TRUE
+Indianapolis,IN,165,White River - White River Plant,2274,1039,Indianapolis | IN,TRUE
+Indianapolis,IN,165,Morse Reservoir,2275,1039,Indianapolis | IN,FALSE
+Indianapolis,IN,165,Geist Reservoir,2276,1039,Indianapolis | IN,FALSE
+Indianapolis,IN,165,Fall Creek - Fall Creek Plant,2277,1039,Indianapolis | IN,FALSE
+Indianapolis,IN,165,Eagle Creek Reservoir,2278,1039,Indianapolis | IN,TRUE
+Indianapolis,IN,165,NA,2279,1039,Indianapolis | IN,FALSE
+Jackson,MS,381,Ross Barnett Reservoir,3743,1326,Jackson | MS,FALSE
+Jackson,MS,381,Pearl River,3683,1326,Jackson | MS,TRUE
+Jacksonville,FL,164,NA,2273,1038,Jacksonville | FL,TRUE
+Johnson City,TN,434,NA,3848,1379,Johnson City | TN,FALSE
+Johnson City,TN,434,Watauga River,3861,1379,Johnson City | TN,TRUE
+Kalamazoo,MI,374,NA,3424,1319,Kalamazoo | MI,TRUE
+Kansas City,MO,380,NA,3426,1325,Kansas City | MO,FALSE
+Kansas City,MO,380,Missouri River - Kansas City MO,3622,1325,Kansas City | MO,TRUE
+Kenosha,WI,467,Lake Michigan,3506,1412,Kenosha | WI,TRUE
+Killeen,TX,447,Lake Belton,3449,1392,Killeen | TX,TRUE
+Kissimmee,FL,325,NA,3360,1271,Kissimmee | FL,TRUE
+Knoxville,TN,435,Tennessee River - Knoxville,4049,1380,Knoxville | TN,TRUE
+Lafayette,IN,350,NA,3832,1295,Lafayette | IN,TRUE
+Lafayette,LA,360,NA,2140,1305,Lafayette | LA,TRUE
+Lake Charles,LA,361,NA,3284,1306,Lake Charles | LA,TRUE
+Lake Charles,LA,361,NA,2140,1306,Lake Charles | LA,TRUE
+Lakeland,FL,326,NA,3360,1272,Lakeland | FL,TRUE
+Lancaster,PA,423,Conestoga River,3300,1368,Lancaster | PA,TRUE
+Lancaster,PA,423,Susquehanna River - Lancaster,3825,1368,Lancaster | PA,TRUE
+Lansing,MI,375,NA,3748,1320,Lansing | MI,TRUE
+Laredo,TX,448,Rio Grande - Laredo,4047,1393,Laredo | TX,TRUE
+Las Cruces,NM,402,NA,3606,1347,Las Cruces | NM,TRUE
+Las Vegas,NV,178,Lake Mead,2327,1052,Las Vegas | NV,TRUE
+Las Vegas,NV,178,NA,2328,1052,Las Vegas | NV,FALSE
+Lexington,KY,356,Jacobson Reservoir,3419,1301,Lexington | KY,FALSE
+Lexington,KY,356,Lake Ellerslie,3468,1301,Lexington | KY,FALSE
+Lexington,KY,356,Kentucky River,3431,1301,Lexington | KY,TRUE
+Lincoln,NE,395,NA,3558,1340,Lincoln | NE,TRUE
+Little Rock,AR,286,Lake Maumelle,3500,1232,Little Rock | AR,TRUE
+Little Rock,AR,286,Lake Winona,3548,1232,Little Rock | AR,TRUE
+Long Beach,CA,179,NA,2329,1053,Long Beach | CA,FALSE
+Long Beach,CA,179,Trinity Lake,2174,1031,Long Beach | CA,FALSE
+Long Beach,CA,179,San Luis Reservoir,2175,1031,Long Beach | CA,TRUE
+Long Beach,CA,179,Castaic Lake,2176,1031,Long Beach | CA,TRUE
+Long Beach,CA,179,Folsom Lake,2177,1031,Long Beach | CA,TRUE
+Long Beach,CA,179,Lake Havasu,3481,1031,Long Beach | CA,TRUE
+Long Beach,CA,179,Perris Reservoir,2179,1031,Long Beach | CA,TRUE
+Long Beach,CA,179,Skinner Reservoir,2180,1031,Long Beach | CA,TRUE
+Long Beach,CA,179,Lake Mathews,2181,1031,Long Beach | CA,TRUE
+Long Beach,CA,179,Silverwood Lake,2182,1031,Long Beach | CA,TRUE
+Long Beach,CA,179,Lake Oroville,2183,1031,Long Beach | CA,TRUE
+Long Beach,CA,179,New Melones Lake,2184,1031,Long Beach | CA,TRUE
+Long Beach,CA,179,Los Banos Reservoir,2185,1031,Long Beach | CA,TRUE
+Long Beach,CA,179,Little Panoche Reservoir,2186,1031,Long Beach | CA,TRUE
+Long Beach,CA,179,Quail Lake,2187,1031,Long Beach | CA,FALSE
+Long Beach,CA,179,Pyramid Lake,2188,1031,Long Beach | CA,TRUE
+Long Beach,CA,179,Lewiston Lake,2189,1031,Long Beach | CA,TRUE
+Long Beach,CA,179,Clifton Forebay,2190,1031,Long Beach | CA,TRUE
+Long Beach,CA,179,Diamond Valley Lake,2191,1031,Long Beach | CA,TRUE
+Long Beach,CA,179,Shasta Lake,2172,1031,Long Beach | CA,TRUE
+Long Beach,CA,179,Whiskeytown Lake,2173,1031,Long Beach | CA,TRUE
+Los Angeles,CA,161,Bouquet Reservoir,2201,1034,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Convict Lake,2202,1034,Los Angeles | CA,FALSE
+Los Angeles,CA,161,Drinkwater Reservoir,2203,1034,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Fairmont Reservoir,2204,1034,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Grant Lake,2205,1034,Los Angeles | CA,FALSE
+Los Angeles,CA,161,Lake Crowley,2206,1034,Los Angeles | CA,FALSE
+Los Angeles,CA,161,Los Angeles Reservoir,2207,1034,Los Angeles | CA,TRUE
+Los Angeles,CA,161,North Haiwee Reservoir,2208,1034,Los Angeles | CA,FALSE
+Los Angeles,CA,161,South Haiwee Reservoir,2209,1034,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Pleasant Valley Reservoir,2210,1034,Los Angeles | CA,FALSE
+Los Angeles,CA,161,Tinemaha Reservoir,2211,1034,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Lee Vining Creek,2212,1034,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Walker Creek,2213,1034,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Parker Creek,2214,1034,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Owens River Below East Portal,2215,1034,Los Angeles | CA,FALSE
+Los Angeles,CA,161,Hot Creek,2216,1034,Los Angeles | CA,FALSE
+Los Angeles,CA,161,Convict Creek,2217,1034,Los Angeles | CA,FALSE
+Los Angeles,CA,161,McGee Creek,2218,1034,Los Angeles | CA,FALSE
+Los Angeles,CA,161,Rock Creek,2219,1034,Los Angeles | CA,FALSE
+Los Angeles,CA,161,Bishop Creek,2220,1034,Los Angeles | CA,FALSE
+Los Angeles,CA,161,Baker Creek,2221,1034,Los Angeles | CA,FALSE
+Los Angeles,CA,161,Big Pine Creek,2222,1034,Los Angeles | CA,FALSE
+Los Angeles,CA,161,Tenehemah Creek,2223,1034,Los Angeles | CA,FALSE
+Los Angeles,CA,161,Owens River below Pine Creek,2224,1034,Los Angeles | CA,FALSE
+Los Angeles,CA,161,Independence Creek,2225,1034,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Lone Pine Creek,2226,1034,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Cottonwood Creek,2227,1034,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Trinity Lake,2174,1031,Los Angeles | CA,FALSE
+Los Angeles,CA,161,San Luis Reservoir,2175,1031,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Castaic Lake,2176,1031,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Folsom Lake,2177,1031,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Lake Havasu,3481,1031,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Perris Reservoir,2179,1031,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Skinner Reservoir,2180,1031,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Lake Mathews,2181,1031,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Silverwood Lake,2182,1031,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Lake Oroville,2183,1031,Los Angeles | CA,TRUE
+Los Angeles,CA,161,New Melones Lake,2184,1031,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Los Banos Reservoir,2185,1031,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Little Panoche Reservoir,2186,1031,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Quail Lake,2187,1031,Los Angeles | CA,FALSE
+Los Angeles,CA,161,Pyramid Lake,2188,1031,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Lewiston Lake,2189,1031,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Clifton Forebay,2190,1031,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Diamond Valley Lake,2191,1031,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Shasta Lake,2172,1031,Los Angeles | CA,TRUE
+Los Angeles,CA,161,Whiskeytown Lake,2173,1031,Los Angeles | CA,TRUE
+Louisville,KY,357,Ohio River Alluvial Aquifer,3669,1302,Louisville | KY,FALSE
+Louisville,KY,357,Ohio River - Louisville,4043,1302,Louisville | KY,TRUE
+Lubbock,TX,449,NA,3202,1394,Lubbock | TX,FALSE
+Lubbock,TX,449,NA,3737,1394,Lubbock | TX,FALSE
+Lubbock,TX,449,Lake Meredith-TX,3504,1394,Lubbock | TX,TRUE
+Macon,GA,335,Javors J. Lucas Lake,3421,1281,Macon | GA,FALSE
+Macon,GA,335,Ocmulgee River,3665,1281,Macon | GA,TRUE
+Madison,WI,468,NA,3579,1413,Madison | WI,TRUE
+Manchester,NH,397,Lake Massabesic,3498,1342,Manchester | NH,TRUE
+Marysville,WA,462,NA,3337,1407,Marysville | WA,FALSE
+Marysville,WA,462,NA,3479,1407,Marysville | WA,FALSE
+Marysville,WA,462,NA,3816,1407,Marysville | WA,FALSE
+Marysville,WA,462,Spada Lake Reservoir,3805,1407,Marysville | WA,TRUE
+McAllen,TX,450,Rio Grande - McAllen,4048,1395,McAllen | TX,TRUE
+Medford,OR,419,NA,3222,1364,Medford | OR,FALSE
+Medford,OR,419,Rogue River,3740,1364,Medford | OR,TRUE
+Memphis,TN,440,NA,3601,1385,Memphis | TN,TRUE
+Merced,CA,295,NA,3603,1241,Merced | CA,TRUE
+Mesa,AZ,180,NA,2330,1054,Mesa | AZ,FALSE
+Mesa,AZ,180,Lake Havasu,3481,1054,Mesa | AZ,TRUE
+Mesa,AZ,180,Lake Pleasant,2148,1054,Mesa | AZ,TRUE
+Mesa,AZ,180,Theodore Roosevelt Lake,2149,1054,Mesa | AZ,FALSE
+Mesa,AZ,180,Apache Lake,2150,1054,Mesa | AZ,FALSE
+Mesa,AZ,180,Canyon Lake,2151,1054,Mesa | AZ,FALSE
+Mesa,AZ,180,Saguaro Lake,2152,1054,Mesa | AZ,TRUE
+Mesa,AZ,180,Horseshoe Reservoir,2153,1054,Mesa | AZ,FALSE
+Mesa,AZ,180,Bartlett Reservoir,2154,1054,Mesa | AZ,TRUE
+Mesa,AZ,180,C. C. Cragin Reservoir,2155,1054,Mesa | AZ,TRUE
+Miami,FL,182,NA,2332,1056,Miami | FL,TRUE
+Milwaukee,WI,469,Lake Michigan,3506,1414,Milwaukee | WI,TRUE
+Minneapolis,MN,185,Mississippi River - Columbia Heights Filtration Plant,2341,1059,Minneapolis | MN,TRUE
+Mission Viejo,CA,296,NA,3620,1242,Mission Viejo | CA,FALSE
+Mission Viejo,CA,296,Diamond Valley Lake,2191,1242,Mission Viejo | CA,TRUE
+Mission Viejo,CA,296,Lake Mathews,2181,1242,Mission Viejo | CA,TRUE
+Mission Viejo,CA,296,Skinner Reservoir,2180,1242,Mission Viejo | CA,TRUE
+Mission Viejo,CA,296,Clifton Forebay,2190,1242,Mission Viejo | CA,TRUE
+Mission Viejo,CA,296,Lewiston Lake,2189,1242,Mission Viejo | CA,TRUE
+Mission Viejo,CA,296,Lake Havasu,3481,1242,Mission Viejo | CA,TRUE
+Mission Viejo,CA,296,Perris Reservoir,2179,1242,Mission Viejo | CA,TRUE
+Mission Viejo,CA,296,Silverwood Lake,2182,1242,Mission Viejo | CA,TRUE
+Mobile,AL,283,J.B. Converse Reservoir,3418,1229,Mobile | AL,TRUE
+Modesto,CA,297,NA,3624,1243,Modesto | CA,FALSE
+Modesto,CA,297,Modesto Reservoir,3625,1243,Modesto | CA,TRUE
+Modesto,CA,297,Tuolumne River,4056,1243,Modesto | CA,TRUE
+Monroe,LA,362,Bayou Bartholomew,3211,1307,Monroe | LA,FALSE
+Monroe,LA,362,Bayou DeSiard,3212,1307,Monroe | LA,FALSE
+Monroe,LA,362,Black Bayou,3229,1307,Monroe | LA,FALSE
+Monroe,LA,362,Ouachita River,3674,1307,Monroe | LA,TRUE
+Montgomery,AL,284,NA,3630,1230,Montgomery | AL,FALSE
+Montgomery,AL,284,Tallapoosa River,3830,1230,Montgomery | AL,TRUE
+Murfreesboro,TN,436,J. Percy Priest Reservoir,3417,1381,Murfreesboro | TN,TRUE
+Murfreesboro,TN,436,East Fork Stones River,3331,1381,Murfreesboro | TN,FALSE
+Muskegon,MI,376,Lake Michigan,3506,1321,Muskegon | MI,TRUE
+Myrtle Beach,SC,431,Atlantic Intracoastal Waterway,3199,1376,Myrtle Beach | SC,TRUE
+Myrtle Beach,SC,431,Pee Dee River,3684,1376,Myrtle Beach | SC,TRUE
+Myrtle Beach,SC,431,Waccamaw River,3856,1376,Myrtle Beach | SC,TRUE
+Nashua,NH,398,NA,3643,1343,Nashua | NH,FALSE
+Nashua,NH,398,Bowers Dam,3239,1343,Nashua | NH,FALSE
+Nashua,NH,398,Harris Pond Dam,3388,1343,Nashua | NH,FALSE
+Nashua,NH,398,Holt Pond Dam,3401,1343,Nashua | NH,FALSE
+Nashua,NH,398,Supply Pond Dam,3824,1343,Nashua | NH,FALSE
+Nashua,NH,398,Merrimack River,3604,1343,Nashua | NH,TRUE
+Nashville,TN,437,Cumberland River - Nashville-Davidson,3312,1382,Nashville | TN,TRUE
+New Bedford,MA,366,Assawompset Pond,3197,1311,New Bedford | MA,TRUE
+New Bedford,MA,366,Great Quittacas Pond,3378,1311,New Bedford | MA,FALSE
+New Bedford,MA,366,Little Quittacas Pond,3561,1311,New Bedford | MA,TRUE
+New Bedford,MA,366,Long Pond,3570,1311,New Bedford | MA,TRUE
+New Bedford,MA,366,Pocksha Pond,3697,1311,New Bedford | MA,FALSE
+New Haven,CT,317,NA,3406,1263,New Haven | CT,FALSE
+New Haven,CT,317,NA,3613,1263,New Haven | CT,FALSE
+New Haven,CT,317,NA,3720,1263,New Haven | CT,FALSE
+New Haven,CT,317,Bethany Lake,3220,1263,New Haven | CT,FALSE
+New Haven,CT,317,Cheshire Reservoir,3283,1263,New Haven | CT,TRUE
+New Haven,CT,317,Glen Lake Reservoir,3371,1263,New Haven | CT,FALSE
+New Haven,CT,317,Lake Chamberlain,3458,1263,New Haven | CT,FALSE
+New Haven,CT,317,Lake Dawson,3464,1263,New Haven | CT,TRUE
+New Haven,CT,317,Lake Gallard,3475,1263,New Haven | CT,TRUE
+New Haven,CT,317,Lake Hammonasset,3480,1263,New Haven | CT,TRUE
+New Haven,CT,317,Lake Watrous,3545,1263,New Haven | CT,FALSE
+New Haven,CT,317,Maltby Lakes,3582,1263,New Haven | CT,TRUE
+New Haven,CT,317,Menuckatuck Reservoir,3602,1263,New Haven | CT,TRUE
+New Haven,CT,317,Millford Reservoir,3615,1263,New Haven | CT,TRUE
+New Haven,CT,317,Wepawaug Reservoir,3863,1263,New Haven | CT,TRUE
+New Haven,CT,317,Whitney Lake,3872,1263,New Haven | CT,TRUE
+New Orleans,LA,363,Mississippi River - New Orleans,4055,1308,New Orleans | LA,TRUE
+New York,NY,162,Schoharie Reservoir,2228,1035,New York | NY,TRUE
+New York,NY,162,Cannonsville Reservoir,2229,1035,New York | NY,TRUE
+New York,NY,162,Pepacton Reservoir,2230,1035,New York | NY,TRUE
+New York,NY,162,Ashokan Reservoir,2231,1035,New York | NY,TRUE
+New York,NY,162,Neversink Reservoir,2232,1035,New York | NY,TRUE
+New York,NY,162,Rondout Reservoir,2233,1035,New York | NY,TRUE
+New York,NY,162,Boyds Corner Reservoir,2234,1035,New York | NY,FALSE
+New York,NY,162,West Branch Reservoir,2235,1035,New York | NY,FALSE
+New York,NY,162,Middle Branch Reservoir,2236,1035,New York | NY,FALSE
+New York,NY,162,East Branch Reservoir,2237,1035,New York | NY,FALSE
+New York,NY,162,Bog Brook Reservoir,2238,1035,New York | NY,FALSE
+New York,NY,162,Croton Falls Reservoir,2239,1035,New York | NY,FALSE
+New York,NY,162,Amawalk Reservoir,2240,1035,New York | NY,FALSE
+New York,NY,162,New Croton Reservoir,2241,1035,New York | NY,TRUE
+New York,NY,162,Muscoot Reservoir,2242,1035,New York | NY,FALSE
+New York,NY,162,Cross River Reservoir,2243,1035,New York | NY,FALSE
+New York,NY,162,Titicus Reservoir,2244,1035,New York | NY,FALSE
+New York,NY,162,Diverting Reservoir,2245,1035,New York | NY,FALSE
+New York,NY,162,Kenisco Reservoir,2246,1035,New York | NY,TRUE
+New York,NY,162,Glenelda Lake,2247,1035,New York | NY,FALSE
+New York,NY,162,Gilead Lake,2248,1035,New York | NY,FALSE
+New York,NY,162,Kirk Lake,2249,1035,New York | NY,FALSE
+Newark,NJ,191,Charlottesburg Reservoir,2364,1066,Newark | NJ,FALSE
+Newark,NJ,191,Echo Lake,2365,1066,Newark | NJ,FALSE
+Newark,NJ,191,Canistear Reservoir,2366,1066,Newark | NJ,FALSE
+Newark,NJ,191,Clinton Reservoir,2367,1066,Newark | NJ,FALSE
+Newark,NJ,191,Oak Ridge Reservoir,2368,1066,Newark | NJ,FALSE
+Newark,NJ,191,Wanaque Reservoir,2369,1066,Newark | NJ,FALSE
+Newark,NJ,191,Monksville Reservoir,2370,1066,Newark | NJ,FALSE
+Newark,NJ,191,Pompton River,2371,1066,Newark | NJ,TRUE
+Newark,NJ,191,Ramapo River,2372,1066,Newark | NJ,FALSE
+Norfolk,VA,556,NA,4223,1498,Norfolk | VA,FALSE
+Norfolk,VA,556,Lake Burnt Mills,3457,1498,Norfolk | VA,FALSE
+Norfolk,VA,556,Western Branch Reservoir-VA,3868,1498,Norfolk | VA,TRUE
+Norfolk,VA,556,Lake Prince,3520,1498,Norfolk | VA,FALSE
+Norfolk,VA,556,Lake Whitehurst,4224,1498,Norfolk | VA,TRUE
+Norfolk,VA,556,Little Creek Reservoir,4225,1498,Norfolk | VA,TRUE
+Norfolk,VA,556,Lake Lawson,4226,1498,Norfolk | VA,TRUE
+Norfolk,VA,556,Lake Smith,4227,1498,Norfolk | VA,TRUE
+Norfolk,VA,556,Lake Wright,4228,1498,Norfolk | VA,FALSE
+Oakland,CA,184,San Pablo Reservoir,2334,1058,Oakland | CA,TRUE
+Oakland,CA,184,Briones Reservoir,2335,1058,Oakland | CA,FALSE
+Oakland,CA,184,Lafayette Reservoir,2336,1058,Oakland | CA,TRUE
+Oakland,CA,184,Upper San Leandro Reservoir,2337,1058,Oakland | CA,FALSE
+Oakland,CA,184,Lake Chabot,2338,1058,Oakland | CA,TRUE
+Oakland,CA,184,Pardee Reservoir,2339,1058,Oakland | CA,FALSE
+Oakland,CA,184,Camanche Reservoir,2340,1058,Oakland | CA,TRUE
+Ocala,FL,327,NA,3360,1273,Ocala | FL,TRUE
+Odessa,TX,451,Lake Ivie,3488,1396,Odessa | TX,TRUE
+Odessa,TX,451,Lake Spence,3531,1396,Odessa | TX,FALSE
+Odessa,TX,451,Lake Thomas,3537,1396,Odessa | TX,TRUE
+Oklahoma City,OK,416,Atoka Reservoir,3200,1361,Oklahoma City | OK,FALSE
+Oklahoma City,OK,416,Canton Reservoir,3261,1361,Oklahoma City | OK,FALSE
+Oklahoma City,OK,416,Hefner Reservoir,3390,1361,Oklahoma City | OK,TRUE
+Oklahoma City,OK,416,McGee Creek Reservoir,3593,1361,Oklahoma City | OK,TRUE
+Oklahoma City,OK,416,Overholser Reservoir,3675,1361,Oklahoma City | OK,TRUE
+Oklahoma City,OK,416,Stanley Draper Reservoir,3814,1361,Oklahoma City | OK,TRUE
+Omaha,NE,396,Platte River,3696,1341,Omaha | NE,TRUE
+Omaha,NE,396,NA,4040,1341,Omaha | NE,FALSE
+Omaha,NE,396,Missouri River - Omaha,4051,1341,Omaha | NE,TRUE
+Orlando,FL,328,NA,3574,1274,Orlando | FL,TRUE
+Oxnard,CA,298,NA,3677,1244,Oxnard | CA,FALSE
+Oxnard,CA,298,Diamond Valley Lake,2191,1244,Oxnard | CA,TRUE
+Oxnard,CA,298,Lake Bard,3448,1244,Oxnard | CA,TRUE
+Oxnard,CA,298,Lake Mathews,2181,1244,Oxnard | CA,TRUE
+Oxnard,CA,298,Skinner Reservoir,2180,1244,Oxnard | CA,TRUE
+Oxnard,CA,298,Clifton Forebay,2190,1244,Oxnard | CA,TRUE
+Oxnard,CA,298,Lewiston Lake,2189,1244,Oxnard | CA,TRUE
+Oxnard,CA,298,Lake Havasu,3481,1244,Oxnard | CA,TRUE
+Oxnard,CA,298,Perris Reservoir,2179,1244,Oxnard | CA,TRUE
+Oxnard,CA,298,Silverwood Lake,2182,1244,Oxnard | CA,TRUE
+Panama (USA),FL,329,Deer Point Reservoir,3315,1275,Panama (USA) | FL,TRUE
+Pensacola,FL,333,NA,3358,1279,Pensacola | FL,TRUE
+Peoria,IL,346,NA,3762,1291,Peoria | IL,FALSE
+Peoria,IL,346,Illinois River,3412,1291,Peoria | IL,TRUE
+Philadelphia,PA,155,Schuylkill River - Queen Lane Plant,2144,1026,Philadelphia | PA,FALSE
+Philadelphia,PA,155,Schuylkill River - Belmont Plant,2145,1026,Philadelphia | PA,TRUE
+Philadelphia,PA,155,Delaware River - Baxter Plant,2146,1026,Philadelphia | PA,TRUE
+Phoenix,AZ,156,Lake Havasu,3481,1027,Phoenix | AZ,TRUE
+Phoenix,AZ,156,Lake Pleasant,2148,1027,Phoenix | AZ,TRUE
+Phoenix,AZ,156,Theodore Roosevelt Lake,2149,1027,Phoenix | AZ,FALSE
+Phoenix,AZ,156,Apache Lake,2150,1027,Phoenix | AZ,FALSE
+Phoenix,AZ,156,Canyon Lake,2151,1027,Phoenix | AZ,FALSE
+Phoenix,AZ,156,Saguaro Lake,2152,1027,Phoenix | AZ,TRUE
+Phoenix,AZ,156,Horseshoe Reservoir,2153,1027,Phoenix | AZ,FALSE
+Phoenix,AZ,156,Bartlett Reservoir,2154,1027,Phoenix | AZ,TRUE
+Phoenix,AZ,156,C. C. Cragin Reservoir,2155,1027,Phoenix | AZ,TRUE
+Pittsburgh,PA,424,Allegheny river,3177,1369,Pittsburgh | PA,TRUE
+Port Arthur,TX,452,LNVA Canal,3565,1397,Port Arthur | TX,TRUE
+Port Arthur,TX,452,Port Arthur Reservoir,3701,1397,Port Arthur | TX,FALSE
+Port Arthur,TX,452,Terminal Reservoir-TX,3835,1397,Port Arthur | TX,TRUE
+Port Saint Lucie,FL,330,NA,3360,1276,Port Saint Lucie | FL,TRUE
+Portland,ME,513,Sebago Lake,4086,1457,Portland | ME,TRUE
+Portland,OR,177,Bull Run Lake,2321,1051,Portland | OR,FALSE
+Portland,OR,177,Bull Run Reservoir No. 1,2322,1051,Portland | OR,FALSE
+Portland,OR,177,Bull Run Reservoir No. 2,2323,1051,Portland | OR,TRUE
+Portland,OR,177,NA,2324,1051,Portland | OR,FALSE
+Portland,OR,177,NA,2325,1051,Portland | OR,FALSE
+Portland,OR,177,NA,2326,1051,Portland | OR,FALSE
+Providence,RI,428,Barden Reservoir,3204,1373,Providence | RI,FALSE
+Providence,RI,428,Moswansicut Reservoir,3635,1373,Providence | RI,FALSE
+Providence,RI,428,Ponneganset Reservoir,3700,1373,Providence | RI,FALSE
+Providence,RI,428,Regulating Reservoir-RI,3729,1373,Providence | RI,TRUE
+Providence,RI,428,Scituate Reservoir,3782,1373,Providence | RI,FALSE
+Providence,RI,428,Westconnaug Reservoir,3867,1373,Providence | RI,FALSE
+Pueblo,CO,315,Pueblo Reservoir,2355,1261,Pueblo | CO,TRUE
+Pueblo,CO,315,Ruedi Reservoir,3744,1261,Pueblo | CO,TRUE
+Pueblo,CO,315,Turquoise Lake,2353,1261,Pueblo | CO,FALSE
+Pueblo,CO,315,Twin Lakes,2354,1261,Pueblo | CO,FALSE
+Racine,WI,470,Lake Michigan,3506,1415,Racine | WI,TRUE
+Raleigh,NC,391,Falls Lake,3352,1336,Raleigh | NC,TRUE
+Reading,PA,425,Lake Ontelaunee,3513,1370,Reading | PA,TRUE
+Redding,CA,299,NA,3728,1245,Redding | CA,FALSE
+Redding,CA,299,Whiskeytown Lake,2173,1245,Redding | CA,TRUE
+Redding,CA,299,Sacramento River - Redding,4041,1245,Redding | CA,TRUE
+Reno,NV,403,NA,3730,1348,Reno | NV,FALSE
+Reno,NV,403,Lake Tahoe,3534,1348,Reno | NV,FALSE
+Reno,NV,403,Boca Reservoir,3230,1348,Reno | NV,TRUE
+Reno,NV,403,Donner Lake,3324,1348,Reno | NV,FALSE
+Reno,NV,403,Independence Lake,3413,1348,Reno | NV,FALSE
+Richmond,VA,457,"James River, VA",4091,1402,Richmond | VA,TRUE
+Roanoke,VA,458,NA,3735,1403,Roanoke | VA,FALSE
+Roanoke,VA,458,Carvin Cove Reservoir,3267,1403,Roanoke | VA,TRUE
+Roanoke,VA,458,NA,3310,1403,Roanoke | VA,FALSE
+Roanoke,VA,458,Falling Creek Reservoir,3350,1403,Roanoke | VA,TRUE
+Roanoke,VA,458,Spring Hollow Reservoir,3809,1403,Roanoke | VA,FALSE
+Roanoke,VA,458,Roanoke River,3736,1403,Roanoke | VA,TRUE
+Rochester,NY,406,Hemlock Lake-NY,3392,1351,Rochester | NY,TRUE
+Rochester,NY,406,Lake Ontario,3512,1351,Rochester | NY,TRUE
+Rochester,NY,406,Canadice Lake,3257,1351,Rochester | NY,FALSE
+Rockford,IL,347,NA,3738,1292,Rockford | IL,TRUE
+Sacramento,CA,300,Sacramento River - Sacramento,4068,1246,Sacramento | CA,FALSE
+Sacramento,CA,300,American River - Sacramento,4069,1246,Sacramento | CA,TRUE
+Sacramento,CA,300,NA,4070,1246,Sacramento | CA,FALSE
+Saginaw,MI,377,Lake Huron,3487,1322,Saginaw | MI,TRUE
+Saint Louis,MO,189,Missouri River - Howard Bend Plant,2360,1064,Saint Louis | MO,FALSE
+Saint Louis,MO,189,Mississippi River - Chain of Rocks Plant,2361,1064,Saint Louis | MO,TRUE
+Saint Paul,MN,190,Mississippi River - Coon Rapids,2362,1065,Saint Paul | MN,TRUE
+Saint Paul,MN,190,NA,2363,1065,Saint Paul | MN,FALSE
+Saint Petersburg,FL,192,NA,2560,1067,Saint Petersburg | FL,FALSE
+Saint Petersburg,FL,192,Hillsborough River,2343,1061,Saint Petersburg | FL,TRUE
+Saint Petersburg,FL,192,Alafia River,2344,1061,Saint Petersburg | FL,TRUE
+Saint Petersburg,FL,192,NA,2346,1061,Saint Petersburg | FL,FALSE
+Salem,OR,420,North Santiam River,3658,1365,Salem | OR,TRUE
+Salinas,CA,301,NA,3751,1247,Salinas | CA,TRUE
+Salt Lake City,UT,456,Jordan River (tributaries),4073,1401,Salt Lake City | UT,TRUE
+Salt Lake City,UT,456,NA,4074,1401,Salt Lake City | UT,FALSE
+San Antonio,TX,157,NA,2156,1028,San Antonio | TX,FALSE
+San Antonio,TX,157,NA,2157,1028,San Antonio | TX,FALSE
+San Antonio,TX,157,NA,2158,1028,San Antonio | TX,FALSE
+San Antonio,TX,157,Canyon Lake,2159,1028,San Antonio | TX,FALSE
+San Antonio,TX,157,Lake Dunlap,4028,1028,San Antonio | TX,TRUE
+San Antonio,TX,157,Medina Lake,4029,1028,San Antonio | TX,TRUE
+San Diego,CA,158,Lake Miramar,2162,1030,San Diego | CA,TRUE
+San Diego,CA,158,Shasta Lake,2172,1031,San Diego | CA,TRUE
+San Diego,CA,158,Murray Reservoir,2163,1030,San Diego | CA,TRUE
+San Diego,CA,158,El Capitan Lake,2164,1030,San Diego | CA,TRUE
+San Diego,CA,158,Lower Otay Lake,2165,1030,San Diego | CA,TRUE
+San Diego,CA,158,Upper Otay Lake,2166,1030,San Diego | CA,FALSE
+San Diego,CA,158,San Vicente Reservoir,2167,1030,San Diego | CA,TRUE
+San Diego,CA,158,Hodges Reservoir,2168,1030,San Diego | CA,TRUE
+San Diego,CA,158,Sutherland Reservoir,2169,1030,San Diego | CA,FALSE
+San Diego,CA,158,Barrett Reservoir,2170,1030,San Diego | CA,TRUE
+San Diego,CA,158,Morena Reservoir,2171,1030,San Diego | CA,FALSE
+San Diego,CA,158,Whiskeytown Lake,2173,1031,San Diego | CA,TRUE
+San Diego,CA,158,Trinity Lake,2174,1031,San Diego | CA,FALSE
+San Diego,CA,158,San Luis Reservoir,2175,1031,San Diego | CA,TRUE
+San Diego,CA,158,Castaic Lake,2176,1031,San Diego | CA,TRUE
+San Diego,CA,158,Folsom Lake,2177,1031,San Diego | CA,TRUE
+San Diego,CA,158,Lake Havasu,3481,1031,San Diego | CA,TRUE
+San Diego,CA,158,Perris Reservoir,2179,1031,San Diego | CA,TRUE
+San Diego,CA,158,Skinner Reservoir,2180,1031,San Diego | CA,TRUE
+San Diego,CA,158,Lake Mathews,2181,1031,San Diego | CA,TRUE
+San Diego,CA,158,Silverwood Lake,2182,1031,San Diego | CA,TRUE
+San Diego,CA,158,Lake Oroville,2183,1031,San Diego | CA,TRUE
+San Diego,CA,158,New Melones Lake,2184,1031,San Diego | CA,TRUE
+San Diego,CA,158,Los Banos Reservoir,2185,1031,San Diego | CA,TRUE
+San Diego,CA,158,Little Panoche Reservoir,2186,1031,San Diego | CA,TRUE
+San Diego,CA,158,Quail Lake,2187,1031,San Diego | CA,FALSE
+San Diego,CA,158,Pyramid Lake,2188,1031,San Diego | CA,TRUE
+San Diego,CA,158,Lewiston Lake,2189,1031,San Diego | CA,TRUE
+San Diego,CA,158,Clifton Forebay,2190,1031,San Diego | CA,TRUE
+San Diego,CA,158,Diamond Valley Lake,2191,1031,San Diego | CA,TRUE
+San Francisco,CA,166,San Antonio Reservoir,2250,1040,San Francisco | CA,TRUE
+San Francisco,CA,166,Hetch Hetchy Reservoir,2252,1040,San Francisco | CA,FALSE
+San Francisco,CA,166,Calaveras Reservoir,2253,1040,San Francisco | CA,TRUE
+San Francisco,CA,166,Cherry Lake,2254,1040,San Francisco | CA,FALSE
+San Francisco,CA,166,Lake Eleanor,2255,1040,San Francisco | CA,FALSE
+San Francisco,CA,166,Lower Crystal Springs Reservoir,2256,1040,San Francisco | CA,TRUE
+San Francisco,CA,166,Upper Crystal Springs Reservoir,2257,1040,San Francisco | CA,FALSE
+San Francisco,CA,166,Pilarcitos Lake,2258,1040,San Francisco | CA,TRUE
+San Francisco,CA,166,Priest Reservoir,2259,1040,San Francisco | CA,FALSE
+San Francisco,CA,166,Moccasin Reservoir,2281,1040,San Francisco | CA,FALSE
+San Francisco,CA,166,Don Pedro Reservoir,2282,1040,San Francisco | CA,TRUE
+San Francisco,CA,166,San Andreas Lake,2280,1040,San Francisco | CA,FALSE
+San Jose,CA,163,Clifton Forebay,2190,1037,San Jose | CA,TRUE
+San Jose,CA,163,San Luis Reservoir,2175,1037,San Jose | CA,TRUE
+San Jose,CA,163,San Antonio Reservoir,2250,1037,San Jose | CA,TRUE
+San Jose,CA,163,Lake del Valle,2251,1037,San Jose | CA,TRUE
+San Jose,CA,163,Hetch Hetchy Reservoir,2252,1037,San Jose | CA,TRUE
+San Jose,CA,163,Calaveras Reservoir,2253,1037,San Jose | CA,TRUE
+San Jose,CA,163,Cherry Lake,2254,1037,San Jose | CA,TRUE
+San Jose,CA,163,Lake Eleanor,2255,1037,San Jose | CA,TRUE
+San Jose,CA,163,Lower Crystal Springs Reservoir,2256,1037,San Jose | CA,TRUE
+San Jose,CA,163,Upper Crystal Springs Reservoir,2257,1037,San Jose | CA,FALSE
+San Jose,CA,163,Pilarcitos Lake,2258,1037,San Jose | CA,TRUE
+San Jose,CA,163,Priest Reservoir,2259,1037,San Jose | CA,TRUE
+San Jose,CA,163,Anderson Lake,2260,1037,San Jose | CA,TRUE
+San Jose,CA,163,Calero Reservoir,2261,1037,San Jose | CA,TRUE
+San Jose,CA,163,Almaden Reservoir,2262,1037,San Jose | CA,TRUE
+San Jose,CA,163,Coyote Lake,2263,1037,San Jose | CA,FALSE
+San Jose,CA,163,Chesbro Reservoir,2264,1037,San Jose | CA,TRUE
+San Jose,CA,163,Guadalupe Reservoir,2265,1037,San Jose | CA,TRUE
+San Jose,CA,163,Lexington Reservoir,2266,1037,San Jose | CA,FALSE
+San Jose,CA,163,Uvas Reservoir,2267,1037,San Jose | CA,TRUE
+San Jose,CA,163,Vasona Reservoir,2268,1037,San Jose | CA,TRUE
+San Jose,CA,163,Stevens Creek Reservoir,2269,1037,San Jose | CA,TRUE
+San Jose,CA,163,NA,2529,1037,San Jose | CA,FALSE
+San Jose,CA,163,NA,2271,1037,San Jose | CA,FALSE
+San Jose,CA,163,Lake Elsman,2272,1036,San Jose | CA,FALSE
+San Jose,CA,163,NA,2270,1036,San Jose | CA,FALSE
+Santa Ana,CA,188,NA,2359,1063,Santa Ana | CA,FALSE
+Santa Ana,CA,188,Trinity Lake,2174,1031,Santa Ana | CA,FALSE
+Santa Ana,CA,188,San Luis Reservoir,2175,1031,Santa Ana | CA,TRUE
+Santa Ana,CA,188,Castaic Lake,2176,1031,Santa Ana | CA,TRUE
+Santa Ana,CA,188,Folsom Lake,2177,1031,Santa Ana | CA,TRUE
+Santa Ana,CA,188,Lake Havasu,3481,1031,Santa Ana | CA,TRUE
+Santa Ana,CA,188,Perris Reservoir,2179,1031,Santa Ana | CA,TRUE
+Santa Ana,CA,188,Skinner Reservoir,2180,1031,Santa Ana | CA,TRUE
+Santa Ana,CA,188,Lake Mathews,2181,1031,Santa Ana | CA,TRUE
+Santa Ana,CA,188,Silverwood Lake,2182,1031,Santa Ana | CA,TRUE
+Santa Ana,CA,188,Lake Oroville,2183,1031,Santa Ana | CA,TRUE
+Santa Ana,CA,188,New Melones Lake,2184,1031,Santa Ana | CA,TRUE
+Santa Ana,CA,188,Los Banos Reservoir,2185,1031,Santa Ana | CA,TRUE
+Santa Ana,CA,188,Little Panoche Reservoir,2186,1031,Santa Ana | CA,TRUE
+Santa Ana,CA,188,Quail Lake,2187,1031,Santa Ana | CA,FALSE
+Santa Ana,CA,188,Pyramid Lake,2188,1031,Santa Ana | CA,TRUE
+Santa Ana,CA,188,Lewiston Lake,2189,1031,Santa Ana | CA,TRUE
+Santa Ana,CA,188,Clifton Forebay,2190,1031,Santa Ana | CA,TRUE
+Santa Ana,CA,188,Diamond Valley Lake,2191,1031,Santa Ana | CA,TRUE
+Santa Ana,CA,188,Shasta Lake,2172,1031,Santa Ana | CA,TRUE
+Santa Ana,CA,188,Whiskeytown Lake,2173,1031,Santa Ana | CA,TRUE
+Santa Barbara,CA,302,NA,3768,1248,Santa Barbara | CA,FALSE
+Santa Barbara,CA,302,NA,3767,1248,Santa Barbara | CA,FALSE
+Santa Barbara,CA,302,Bradbury Dam,3241,1248,Santa Barbara | CA,TRUE
+Santa Barbara,CA,302,Gibraltar Reservoir,3369,1248,Santa Barbara | CA,FALSE
+Santa Barbara,CA,302,Lake Oroville,2183,1248,Santa Barbara | CA,TRUE
+Santa Barbara,CA,302,San Luis Reservoir,2175,1248,Santa Barbara | CA,TRUE
+Santa Barbara,CA,302,Clifton Forebay,2190,1248,Santa Barbara | CA,TRUE
+Santa Barbara,CA,302,Lewiston Lake,2189,1248,Santa Barbara | CA,TRUE
+Santa Clarita,CA,303,NA,3770,1249,Santa Clarita | CA,FALSE
+Santa Clarita,CA,303,NA,3776,1249,Santa Clarita | CA,FALSE
+Santa Clarita,CA,303,Castaic Lake,2176,1249,Santa Clarita | CA,TRUE
+Santa Clarita,CA,303,Lake Oroville,2183,1249,Santa Clarita | CA,TRUE
+Santa Clarita,CA,303,Perris Reservoir,2179,1249,Santa Clarita | CA,TRUE
+Santa Clarita,CA,303,Pyramid Lake,2188,1249,Santa Clarita | CA,TRUE
+Santa Clarita,CA,303,Quail Lake,2187,1249,Santa Clarita | CA,FALSE
+Santa Clarita,CA,303,San Luis Reservoir,2175,1249,Santa Clarita | CA,TRUE
+Santa Clarita,CA,303,Silverwood Lake,2182,1249,Santa Clarita | CA,TRUE
+Santa Clarita,CA,303,Clifton Forebay,2190,1249,Santa Clarita | CA,TRUE
+Santa Clarita,CA,303,Lewiston Lake,2189,1249,Santa Clarita | CA,TRUE
+Santa Cruz,CA,304,NA,3715,1250,Santa Cruz | CA,FALSE
+Santa Cruz,CA,304,Majors Creek,3655,1250,Santa Cruz | CA,FALSE
+Santa Cruz,CA,304,Loch Lomond Reservoir,3566,1250,Santa Cruz | CA,FALSE
+Santa Cruz,CA,304,San Lorenzo River,3763,1250,Santa Cruz | CA,TRUE
+Santa Cruz,CA,304,Laguna Creek,4057,1250,Santa Cruz | CA,TRUE
+Santa Fe,NM,561,McClure Reservoir,4246,1503,Santa Fe | NM,FALSE
+Santa Fe,NM,561,Nichols Reservoir,4247,1503,Santa Fe | NM,TRUE
+Santa Fe,NM,561,Rio Grande - Buckman Diversion,4248,1503,Santa Fe | NM,TRUE
+Santa Fe,NM,561,NA,4249,1503,Santa Fe | NM,FALSE
+Santa Maria,CA,305,NA,3773,1251,Santa Maria | CA,FALSE
+Santa Maria,CA,305,Lake Oroville,2183,1251,Santa Maria | CA,TRUE
+Santa Maria,CA,305,San Luis Reservoir,2175,1251,Santa Maria | CA,TRUE
+Santa Maria,CA,305,Clifton Forebay,2190,1251,Santa Maria | CA,TRUE
+Santa Maria,CA,305,Lewiston Lake,2189,1251,Santa Maria | CA,TRUE
+Santa Rosa,CA,306,NA,3745,1252,Santa Rosa | CA,FALSE
+Santa Rosa,CA,306,NA,3774,1252,Santa Rosa | CA,FALSE
+Santa Rosa,CA,306,Lake Mendocino,3502,1252,Santa Rosa | CA,FALSE
+Santa Rosa,CA,306,Lake Pillsbury,3518,1252,Santa Rosa | CA,TRUE
+Santa Rosa,CA,306,Lake Sonoma,3529,1252,Santa Rosa | CA,FALSE
+Santa Rosa,CA,306,Russian River to Mirabel Dam,4053,1252,Santa Rosa | CA,TRUE
+Savannah,GA,336,NA,3360,1282,Savannah | GA,TRUE
+Scranton,PA,426,Griffin Reservoir,3381,1371,Scranton | PA,TRUE
+Scranton,PA,426,Lake Scranton Reservoir,3527,1371,Scranton | PA,TRUE
+Scranton,PA,426,Summit Lake Reservoir,3823,1371,Scranton | PA,TRUE
+Seattle,WA,174,Cedar River - Landsburg diversion dam,2305,1048,Seattle | WA,TRUE
+Seattle,WA,174,South Fork Tolt Reservoir,2306,1048,Seattle | WA,TRUE
+Shreveport,LA,364,Cross Lake,3305,1309,Shreveport | LA,TRUE
+Shreveport,LA,364,Twelve Mile Bayou,3844,1309,Shreveport | LA,TRUE
+Simi Valley,CA,307,NA,3793,1253,Simi Valley | CA,FALSE
+Simi Valley,CA,307,Castaic Lake,2176,1253,Simi Valley | CA,TRUE
+Simi Valley,CA,307,Lake Oroville,2183,1253,Simi Valley | CA,TRUE
+Simi Valley,CA,307,Perris Reservoir,2179,1253,Simi Valley | CA,TRUE
+Simi Valley,CA,307,Pyramid Lake,2188,1253,Simi Valley | CA,TRUE
+Simi Valley,CA,307,Quail Lake,2187,1253,Simi Valley | CA,FALSE
+Simi Valley,CA,307,San Luis Reservoir,2175,1253,Simi Valley | CA,TRUE
+Simi Valley,CA,307,Silverwood Lake,2182,1253,Simi Valley | CA,TRUE
+Simi Valley,CA,307,Clifton Forebay,2190,1253,Simi Valley | CA,TRUE
+Simi Valley,CA,307,Lewiston Lake,2189,1253,Simi Valley | CA,TRUE
+Simi Valley,CA,307,Lake Havasu,3481,1253,Simi Valley | CA,TRUE
+Simi Valley,CA,307,Skinner Reservoir,2180,1253,Simi Valley | CA,TRUE
+Simi Valley,CA,307,Diamond Valley Lake,2191,1253,Simi Valley | CA,TRUE
+Simi Valley,CA,307,Lake Mathews,2181,1253,Simi Valley | CA,TRUE
+Sioux City,IA,343,NA,3313,1288,Sioux City | IA,FALSE
+Sioux City,IA,343,Missouri River Alluvial Aquifer,3623,1288,Sioux City | IA,TRUE
+Sioux Falls,SD,433,NA,3224,1378,Sioux Falls | SD,FALSE
+Sioux Falls,SD,433,NA,3611,1378,Sioux Falls | SD,FALSE
+Sioux Falls,SD,433,NA,3807,1378,Sioux Falls | SD,FALSE
+Sioux Falls,SD,433,Big Sioux River,3225,1378,Sioux Falls | SD,TRUE
+South Bend,IN,353,NA,3396,1298,South Bend | IN,TRUE
+South Bend,IN,353,NA,3812,1298,South Bend | IN,TRUE
+Spartanburg,SC,432,Lake Blalock,3452,1377,Spartanburg | SC,TRUE
+Spartanburg,SC,432,Lake Bowen,3454,1377,Spartanburg | SC,FALSE
+Spartanburg,SC,432,Municipal Reservoir No. 1,3638,1377,Spartanburg | SC,FALSE
+Spokane,WA,464,NA,3808,1409,Spokane | WA,TRUE
+Springfield,IL,348,Lake Springfield,3532,1293,Springfield | IL,TRUE
+Springfield,IL,348,Sangamon River,3766,1293,Springfield | IL,TRUE
+Springfield,MA,367,Cobble Mountain Reservoir,3293,1312,Springfield | MA,TRUE
+Springfield,MO,379,NA,3365,1324,Springfield | MO,FALSE
+Springfield,MO,379,NA,3810,1324,Springfield | MO,FALSE
+Springfield,MO,379,Fellows Lake,3355,1324,Springfield | MO,FALSE
+Springfield,MO,379,McDaniel Lake,3592,1324,Springfield | MO,FALSE
+Springfield,MO,379,Stockton Lake,3818,1324,Springfield | MO,TRUE
+Springfield,MO,379,"James River, MO",3420,1324,Springfield | MO,TRUE
+Stockton,CA,308,NA,3759,1254,Stockton | CA,FALSE
+Stockton,CA,308,NA,3817,1254,Stockton | CA,FALSE
+Stockton,CA,308,New Hogan Reservoir,3649,1254,Stockton | CA,TRUE
+Stockton,CA,308,New Melones Lake,2184,1254,Stockton | CA,TRUE
+Syracuse,NY,407,Lake Ontario,3512,1352,Syracuse | NY,TRUE
+Syracuse,NY,407,Skaneateles Lake,3798,1352,Syracuse | NY,TRUE
+Tallahassee,FL,331,NA,3360,1277,Tallahassee | FL,TRUE
+Tampa,FL,186,Hillsborough River,2343,1060,Tampa | FL,TRUE
+Tampa,FL,186,Hillsborough River,2343,1061,Tampa | FL,TRUE
+Tampa,FL,186,Alafia River,2344,1061,Tampa | FL,TRUE
+Tampa,FL,186,NA,2345,1061,Tampa | FL,FALSE
+Tampa,FL,186,NA,2346,1061,Tampa | FL,FALSE
+Thousand Oaks,CA,309,Clifton Forebay,2190,1255,Thousand Oaks | CA,TRUE
+Thousand Oaks,CA,309,Lewiston Lake,2189,1255,Thousand Oaks | CA,TRUE
+Thousand Oaks,CA,309,Silverwood Lake,2182,1255,Thousand Oaks | CA,TRUE
+Toledo,OH,414,Lake Erie,3469,1359,Toledo | OH,TRUE
+Topeka,KS,354,Kansas River,3427,1299,Topeka | KS,TRUE
+Trenton,NJ,400,Delaware River,3316,1345,Trenton | NJ,TRUE
+Tucson,AZ,288,NA,3841,1234,Tucson | AZ,FALSE
+Tucson,AZ,288,Lake Havasu,3481,1234,Tucson | AZ,TRUE
+Tucson,AZ,288,Lake Pleasant,2148,1234,Tucson | AZ,TRUE
+Tulsa,OK,417,Lake Eucha,3470,1362,Tulsa | OK,FALSE
+Tulsa,OK,417,Lake Hudson,3486,1362,Tulsa | OK,TRUE
+Tulsa,OK,417,Lake Oologah,3514,1362,Tulsa | OK,TRUE
+Tulsa,OK,417,Lake Spavinaw,3530,1362,Tulsa | OK,TRUE
+Tuscaloosa,AL,285,Harris Lake,3387,1231,Tuscaloosa | AL,FALSE
+Tuscaloosa,AL,285,Lake Nicol,3509,1231,Tuscaloosa | AL,FALSE
+Tuscaloosa,AL,285,Lake Tuscaloosa,3539,1231,Tuscaloosa | AL,TRUE
+Tyler,TX,453,NA,3266,1398,Tyler | TX,FALSE
+Tyler,TX,453,Lake Palestine,3516,1398,Tyler | TX,TRUE
+Tyler,TX,453,Lake Tyler,3540,1398,Tyler | TX,TRUE
+Tyler,TX,453,Lake Tyler East,3541,1398,Tyler | TX,TRUE
+Utica,NY,408,Hinckley Reservoir,3397,1353,Utica | NY,TRUE
+Vallejo,CA,310,Lake Berryessa,3451,1256,Vallejo | CA,FALSE
+Vallejo,CA,310,Lake Frey,3474,1256,Vallejo | CA,TRUE
+Vallejo,CA,310,Lake Madigan,3497,1256,Vallejo | CA,FALSE
+Vallejo,CA,310,Lake Oroville,2183,1256,Vallejo | CA,TRUE
+Vallejo,CA,310,Sacramento River - North Bay aqueduct intake,3747,1256,Vallejo | CA,TRUE
+Virginia Beach,VA,459,NA,3854,1404,Virginia Beach | VA,FALSE
+Virginia Beach,VA,459,Lake Burnt Mills,3457,1404,Virginia Beach | VA,FALSE
+Virginia Beach,VA,459,Lake Gaston,3476,1404,Virginia Beach | VA,TRUE
+Virginia Beach,VA,459,Lake Prince,3520,1404,Virginia Beach | VA,FALSE
+Virginia Beach,VA,459,Western Branch Reservoir-VA,3868,1404,Virginia Beach | VA,TRUE
+Visalia,CA,311,NA,3855,1257,Visalia | CA,TRUE
+Waco,TX,454,Lake Belton,3449,1399,Waco | TX,TRUE
+Waco,TX,454,Lake Waco,3543,1399,Waco | TX,TRUE
+Washington,D.C.,175,Potomac River - Dalecarlia Reservoir,2309,1049,Washington | D.C.,TRUE
+Washington,D.C.,175,Potomac River - McMillan WTP,2310,1049,Washington | D.C.,FALSE
+Waterbury,CT,318,Cairnes Reservoir,3254,1264,Waterbury | CT,FALSE
+Waterbury,CT,318,Morris Reservoir,3633,1264,Waterbury | CT,FALSE
+Waterbury,CT,318,Pitch Reservoir,3694,1264,Waterbury | CT,FALSE
+Waterbury,CT,318,Shepaug Reservoir,3787,1264,Waterbury | CT,TRUE
+Waterbury,CT,318,Wigwam Reservoir,3874,1264,Waterbury | CT,TRUE
+Waterloo,IA,341,NA,3275,1286,Waterloo | IA,FALSE
+Waterloo,IA,341,Cedar River Alluvial Aquifer - Waterloo,4035,1286,Waterloo | IA,TRUE
+Wichita,KS,355,NA,3345,1300,Wichita | KS,FALSE
+Wichita,KS,355,Cheney Reservoir,3281,1300,Wichita | KS,TRUE
+Wilmington,NC,392,NA,3269,1337,Wilmington | NC,FALSE
+Wilmington,NC,392,Cape Fear River - Wilmington,4034,1337,Wilmington | NC,TRUE
+Winston-Salem,NC,393,Salem Lake,3750,1338,Winston-Salem | NC,TRUE
+Winston-Salem,NC,393,Yadkin River - Winston-Salem,4052,1338,Winston-Salem | NC,TRUE
+Winter Haven,FL,332,NA,3360,1278,Winter Haven | FL,TRUE
+Worcester,MA,368,NA,3292,1313,Worcester | MA,FALSE
+Worcester,MA,368,NA,3789,1313,Worcester | MA,FALSE
+Worcester,MA,368,Holden Reservoir No. 1,3399,1313,Worcester | MA,FALSE
+Worcester,MA,368,Holden Reservoir No. 2,3400,1313,Worcester | MA,TRUE
+Worcester,MA,368,Kendal Reservoir,3428,1313,Worcester | MA,FALSE
+Worcester,MA,368,Kettle Brook Reservoir No. 1,3433,1313,Worcester | MA,FALSE
+Worcester,MA,368,Kettle Brook Reservoir No. 2,3434,1313,Worcester | MA,FALSE
+Worcester,MA,368,Kettle Brook Reservoir No. 3,3435,1313,Worcester | MA,FALSE
+Worcester,MA,368,Kettle Brook Reservoir No. 4,3436,1313,Worcester | MA,FALSE
+Worcester,MA,368,Lynde Brook Reservoir,3578,1313,Worcester | MA,TRUE
+Worcester,MA,368,Pine Hill Reservoir,3692,1313,Worcester | MA,FALSE
+Worcester,MA,368,Wachusett Reservoir,2303,1313,Worcester | MA,TRUE
+Worcester,MA,368,Quinapoxet Reservoir,4075,1313,Worcester | MA,FALSE
+Yakima,WA,463,NA,3344,1408,Yakima | WA,FALSE
+Yakima,WA,463,Naches River,3642,1408,Yakima | WA,TRUE
+York,PA,427,Lake Redman,3523,1372,York | PA,FALSE
+York,PA,427,Lake Williams,3546,1372,York | PA,FALSE
+York,PA,427,Susquehanna River - York,4038,1372,York | PA,TRUE
+Youngstown,OH,415,Meander Reservoir,3598,1360,Youngstown | OH,TRUE

--- a/man/count_watershed_teleconnections.Rd
+++ b/man/count_watershed_teleconnections.Rd
@@ -31,6 +31,8 @@ count_watershed_teleconnections(data_dir,
 \item{poly_slices}{integer for how may parts to split the watersheds polygons into to enable faster zonal stats}
 
 \item{n_cores}{integer for the number of machine cores used to run the polygon slicing function. 2 is default for users with 16GB of RAM.}
+
+\item{nuld_file_path}{path of land use raster file.}
 }
 \description{
 count_watershed_teleconnections


### PR DESCRIPTION
By adding the DVTR_ID from the Microsoft Access file, cities are now mapped to all of their watersheds. The DVTR table that was pulled from that access file is located in /data/water/TBL_City_DVTR_DVSN.csv (just for reference). This file was joined with the watershed shapefile and then organized to be just like the city_intake_mapping file, just with the DVTR_ID column added. This resolves #15, but does bring back our problem of processing cities with multiple large watersheds. The slice code can only work for cities with one large watershed, so we will need to update that.