### PR TITLE
Nhd flow script

### DIFF
--- a/R/constants.R
+++ b/R/constants.R
@@ -36,5 +36,5 @@ ltrday_to_m3sec <- 1.15741e-8
 
 cfs_to_m3sec <- 0.0283168
 
-
+nhdplus_flow_metric <- "Q0001C"
 

--- a/R/count_teleconnections.R
+++ b/R/count_teleconnections.R
@@ -290,16 +290,12 @@ count_watershed_teleconnections <- function(data_dir,
           x$metrics %>% filter(metric == "cultivated runoff") %>%
             .[["value"]] -> cropland_runoff
 
-          as.numeric(total_runoff) -> total_runoff_num
-          as.numeric(dev_runoff) -> dev_runoff_num
-          as.numeric(cropland_runoff) -> cropland_runoff_num
+          tibble(total_runoff, dev_runoff, cropland_runoff) %>%
+            mutate(nonpristine_conc = (dev_runoff + cropland_runoff) / total_runoff,
+                   ag_conc = cropland_runoff / total_runoff,
+                   dev_conc = dev_runoff / total_runoff) %>%
+            select(nonpristine_conc, ag_conc, dev_conc)
 
-          tibble(total_runoff, dev_runoff, cropland_runoff) -> runoff_df
-          runoff_df %>%
-            mutate(nonpristine_conc = (dev_runoff_num + cropland_runoff_num) / total_runoff_num,
-                   ag_conc = (cropland_runoff_num / total_runoff_num),
-                   dev_conc = (dev_runoff_num / total_runoff_num)) %>%
-            select(nonpristine_conc, ag_conc, dev_conc) -> test2
         }) -> runoff_contaminant_concentrations
 
         names(runoff_contaminant_concentrations) %>%
@@ -317,12 +313,19 @@ count_watershed_teleconnections <- function(data_dir,
             mutate(conc = x * contribution_to_supply) %>% .[["conc"]] %>% sum()
         }
 
+
         get_average_runoff_conc_exgw <- function(metric){
           runoff_contaminant_and_contributions %>%
             select(x = one_of(metric), contribution_to_supply) %>%
             filter(!is.na(x)) %>%
             mutate(conc = x * contribution_to_supply) -> concs
           sum(concs[["conc"]]) / sum(concs[["contribution_to_supply"]])
+        }
+
+        get_average_runoff_conc_exgw_unweighted <- function(metric){
+          runoff_contaminant_and_contributions %>%
+            select(x = one_of(metric)) %>%
+            filter(!is.na(x)) %>% .[["x"]] %>% mean()
         }
 
         get_max_runoff_conc <- function(metric){
@@ -341,6 +344,7 @@ count_watershed_teleconnections <- function(data_dir,
 
         np_runoff_max <- get_max_runoff_conc("nonpristine_conc")
         np_runoff_av_exgw <- get_average_runoff_conc_exgw("nonpristine_conc")
+        np_runoff_av_exgw_unweighted <- get_average_runoff_conc_exgw_unweighted("nonpristine_conc")
         np_runoff_av <- get_average_runoff_conc("nonpristine_conc")
 
         # # total runoff
@@ -427,9 +431,8 @@ count_watershed_teleconnections <- function(data_dir,
         # runoff, flow, and wastewater plant discharge
         map(city_watershed_data, function(x){
           x$metrics %>%
-            filter(metric %in% c(#"average historical runoff",
+            filter(metric %in% c("average historical runoff",
                                  "average historical flow",
-                                 "nhd flow",
                                  "driest month average runoff",
                                  "driest month average flow")) %>%
             select(-unit)
@@ -447,13 +450,8 @@ count_watershed_teleconnections <- function(data_dir,
             runoff_and_flows[[DVSN]] %>%
               mutate(DVSN_ID = !! DVSN) %>%
               left_join(wastewater_discharge_m3sec, by = "DVSN_ID")
-          }) -> discharge_df
-
-          as.numeric(discharge_df$value) -> discharge_df$value
-          as.numeric(discharge_df$wastewater_discharge_m3sec) -> discharge_df$wastewater_discharge_m3sec
-
-          discharge_df %>%
-          dplyr::mutate(conc_pct = 100 * (wastewater_discharge_m3sec / value)) %>%
+          }) %>%
+          mutate(conc_pct = 100 * (wastewater_discharge_m3sec / (value + wastewater_discharge_m3sec))) %>%
           select(DVSN_ID, metric, conc_pct) %>%
           split(.$metric) %>%
           map(function(x) right_join(x, source_contributions, by = "DVSN_ID")) ->
@@ -466,6 +464,13 @@ count_watershed_teleconnections <- function(data_dir,
               summarise(conc = sum(conc_pct * contribution_to_supply) / sum(contribution_to_supply)) %>%
               .[["conc"]]
           }) -> surface_water_concentrations
+
+        # unweighted mean concentration of surface water supply
+        flow_and_runoff_metrics_and_contributions %>%
+          map(function(x){
+            x %>% filter(type == "surface water") %>%
+              .[["conc_pct"]] %>% mean()
+          }) -> surface_water_concentrations_unweighted
 
         # mean concentration of all water supply
         flow_and_runoff_metrics_and_contributions %>%
@@ -484,8 +489,7 @@ count_watershed_teleconnections <- function(data_dir,
           }) -> surface_water_concentration_worst
 
         # importance of worst-case surface water supply DVSN
-        #flow_and_runoff_metrics_and_contributions$`average historical runoff` %>%
-        flow_and_runoff_metrics_and_contributions$`nhd flow` %>%
+        flow_and_runoff_metrics_and_contributions$`average historical flow` %>%
           filter(type == "surface water") %>%
           filter(conc_pct == max(conc_pct)) %>%
           .[["contribution_to_supply"]] %>% dplyr::first() * 100 ->
@@ -551,6 +555,7 @@ count_watershed_teleconnections <- function(data_dir,
                  dev_runoff_av,
                  np_runoff_max,
                  np_runoff_av_exgw,
+                 np_runoff_av_exgw_unweighted,
                  np_runoff_av,
                  n_economic_sectors,
                  max_withdr_dist_km,
@@ -558,22 +563,19 @@ count_watershed_teleconnections <- function(data_dir,
                  n_treatment_plants,
                  watershed_pop,
                  pop_cons_m3sec,
-                 nhd_average_flow,
                  av_fl_sur_conc_pct = surface_water_concentrations[["average historical flow"]],
-                 dr_fl_sur_conc_pct = surface_water_concentrations[["driest month average flow"]],
-                 #av_ro_sur_conc_pct = surface_water_concentrations[["average historical runoff"]],
-                 av_ro_sur_conc_pct = surface_water_concentrations[["nhd flow"]],
-                 dr_ro_sur_conc_pct = surface_water_concentrations[["driest month average runoff"]],
+                 av_fl_sur_conc_pct_unweighted = surface_water_concentrations_unweighted[["average historical flow"]],
+                 #dr_fl_sur_conc_pct = surface_water_concentrations[["driest month average flow"]],
+                 av_ro_sur_conc_pct = surface_water_concentrations[["average historical runoff"]],
+                 #dr_ro_sur_conc_pct = surface_water_concentrations[["driest month average runoff"]],
                  av_fl_all_conc_pct = all_water_concentrations[["average historical flow"]],
-                 dr_fl_all_conc_pct = all_water_concentrations[["driest month average flow"]],
-                 #av_ro_all_conc_pct = all_water_concentrations[["average historical runoff"]],
-                 av_ro_all_conc_pct = all_water_concentrations[["nhd flow"]],
-                 dr_ro_all_conc_pct = all_water_concentrations[["driest month average runoff"]],
+                 #dr_fl_all_conc_pct = all_water_concentrations[["driest month average flow"]],
+                 av_ro_all_conc_pct = all_water_concentrations[["average historical runoff"]],
+                 #dr_ro_all_conc_pct = all_water_concentrations[["driest month average runoff"]],
                  av_fl_max_conc_pct = surface_water_concentration_worst[["average historical flow"]],
-                 dr_fl_max_conc_pct = surface_water_concentration_worst[["driest month average flow"]],
-                 #av_ro_max_conc_pct = surface_water_concentration_worst[["average historical runoff"]],
-                 av_ro_max_conc_pct = surface_water_concentration_worst[["nhd flow"]],
-                 dr_ro_max_conc_pct = surface_water_concentration_worst[["driest month average runoff"]],
+                 #dr_fl_max_conc_pct = surface_water_concentration_worst[["driest month average flow"]],
+                 av_ro_max_conc_pct = surface_water_concentration_worst[["average historical runoff"]],
+                 #dr_ro_max_conc_pct = surface_water_concentration_worst[["driest month average runoff"]],
                  surface_contribution_pct,
                  importance_of_worst_watershed_pct)
         )

--- a/R/count_watershed_data.R
+++ b/R/count_watershed_data.R
@@ -267,10 +267,20 @@ count_watershed_data <- function(data_dir,
 
         # Calculate flow from NHD flowline
 
-        watershed_nhd_flows %>%
-          filter(DVSN_ID %in% watershed) -> nhd_flow
+        if(watershed %in% watershed_nhd_flows$DVSN_ID == TRUE){
 
-        if_else(length(nhd_flow$.[1]) == 0, historical_runoff_mean_m3sec, nhd_flow$Q0001E[1]) -> nhd_mean_flow_m3sec
+          watershed_nhd_flows %>%
+            filter(DVSN_ID %in% watershed) %>%
+            as_tibble() %>%
+            .[["Q0001E"]] -> nhd_flow
+
+          if_else(is.na(nhd_flow) == TRUE, historical_runoff_mean_m3sec, nhd_flow) -> nhd_mean_flow_m3sec
+
+        }else{
+
+          historical_runoff_mean_m3sec -> nhd_mean_flow_m3sec
+
+        }
 
         #-------------------------------------------------------
         # TELECONNECTION - NUMBER OF CROP TYPES BASED ON GCAM CLASSES. NUMBER OF LAND COVERS.

--- a/man/count_watershed_data.Rd
+++ b/man/count_watershed_data.Rd
@@ -19,7 +19,8 @@ count_watershed_data(
     transfers = "water/transfers/USIBTsHUC6_Dickson.shp", climate =
     "land/kop_climate_classes.tif", HUC4 = "water/USA_HUC4/huc4_to_huc2.shp", population
     = "land/pden2010_block/pden2010_60m.tif", runoff =
-    "water/Historical_Mean_Runoff/USA_Mean_Runoff.tif")
+    "water/Historical_Mean_Runoff/USA_Mean_Runoff.tif", nhd_flow =
+    "water/Watershed_Flow_Contributions/UWB_Intake_Flows.shp")
 )
 }
 \arguments{

--- a/man/count_watershed_teleconnections.Rd
+++ b/man/count_watershed_teleconnections.Rd
@@ -19,7 +19,8 @@ count_watershed_teleconnections(
     transfers = "water/transfers/USIBTsHUC6_Dickson.shp", climate =
     "land/kop_climate_classes.tif", HUC4 = "water/USA_HUC4/huc4_to_huc2.shp", population
     = "land/pden2010_block/pden2010_60m.tif", runoff =
-    "water/Historical_Mean_Runoff/USA_Mean_Runoff.tif")
+    "water/Historical_Mean_Runoff/USA_Mean_Runoff.tif", nhd_flow =
+    "water/Watershed_Flow_Contributions/UWB_Intake_Flows.shp")
 )
 }
 \arguments{


### PR DESCRIPTION
Add in new NHD flow calculations and use them instead of the "average historical runoff" for the defacto waste water use. Lines that originally used the average historical runoff have been commented out incase we want to revert at any time. The NHD files have been uploaded to pic in the folder Watershed_Flow_Contributions. This resolves #93 